### PR TITLE
Add initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: cpp
+sudo: required
+
+services: docker
+
+before_install:
+ - docker pull ubuntu
+ - docker run --cidfile /tmp/id -it -d ubuntu /bin/bash
+ - tar cf csd.tar * && docker cp csd.tar $(cat /tmp/id):/tmp/
+ - docker exec -i $(cat /tmp/id) /bin/bash -c "apt-get update -qq && apt-get install -y -q libavahi-glib-dev libavahi-client-dev libavahi-core-dev libgstreamer1.0-dev libgstrtspserver-1.0-dev libgstreamer-plugins-base1.0-dev build-essential autoconf libtool wget"
+   # newer libgstrtspserver packages
+ - docker exec -i $(cat /tmp/id) /bin/bash -c "wget http://security.ubuntu.com/ubuntu/pool/universe/g/gst-rtsp-server1.0/libgstrtspserver-1.0-0_1.8.3-1_amd64.deb && wget http://security.ubuntu.com/ubuntu/pool/universe/g/gst-rtsp-server1.0/libgstrtspserver-1.0-dev_1.8.3-1_amd64.deb && wget http://security.ubuntu.com/ubuntu/pool/universe/g/gst-rtsp-server1.0/gir1.2-gst-rtsp-server-1.0_1.8.3-1_amd64.deb && dpkg -i *.deb"
+
+script:  
+ - docker exec -i $(cat /tmp/id) /bin/bash -c "mkdir /tmp/csd && tar vxf /tmp/csd.tar -C /tmp/csd && cd /tmp/csd/ && ./autogen.sh"
+ - docker exec -i $(cat /tmp/id) /bin/bash -c "cd /tmp/csd && ./configure && make -j"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
-language: cpp
-sudo: required
-
+language: generic
 services: docker
 
 before_install:
- - docker pull ubuntu
- - docker run --cidfile /tmp/id -it -d ubuntu /bin/bash
+ - docker run --cidfile /tmp/id -it -d anselmolsm/travis_ci_deps:ubuntu1604 /bin/bash
  - tar cf csd.tar * && docker cp csd.tar $(cat /tmp/id):/tmp/
- - docker exec -i $(cat /tmp/id) /bin/bash -c "apt-get update -qq && apt-get install -y -q libavahi-glib-dev libavahi-client-dev libavahi-core-dev libgstreamer1.0-dev libgstrtspserver-1.0-dev libgstreamer-plugins-base1.0-dev build-essential autoconf libtool wget"
-   # newer libgstrtspserver packages
- - docker exec -i $(cat /tmp/id) /bin/bash -c "wget http://security.ubuntu.com/ubuntu/pool/universe/g/gst-rtsp-server1.0/libgstrtspserver-1.0-0_1.8.3-1_amd64.deb && wget http://security.ubuntu.com/ubuntu/pool/universe/g/gst-rtsp-server1.0/libgstrtspserver-1.0-dev_1.8.3-1_amd64.deb && wget http://security.ubuntu.com/ubuntu/pool/universe/g/gst-rtsp-server1.0/gir1.2-gst-rtsp-server-1.0_1.8.3-1_amd64.deb && dpkg -i *.deb"
 
 script:  
- - docker exec -i $(cat /tmp/id) /bin/bash -c "mkdir /tmp/csd && tar vxf /tmp/csd.tar -C /tmp/csd && cd /tmp/csd/ && ./autogen.sh"
- - docker exec -i $(cat /tmp/id) /bin/bash -c "cd /tmp/csd && ./configure && make -j"
+ - docker exec -i $(cat /tmp/id) /bin/bash -c "cd /tmp/ && tar xf csd.tar && ./autogen.sh"
+ - docker exec -i $(cat /tmp/id) /bin/bash -c "cd /tmp/ && ./configure && make -j"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## Camera Streaming Daemon ##
 
-[![Build Status](https://travis-ci.org/01org/camera-streaming-daemon.svg?branch=master)](https://travis-ci.org/01org/camera-streaming-daemon)
+[![Build Status](https://travis-ci.org/01org/camera-streaming-daemon.svg?branch=master)](https://travis-ci.org/01org/camera-streaming-daemon) <a href="https://scan.coverity.com/projects/01org-camera-streaming-daemon">
+  <img alt="Coverity Scan Build Status"
+       src="https://scan.coverity.com/projects/12056/badge.svg"/>
+</a>
 
 ### Compilation and installation ###
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ## Camera Streaming Daemon ##
 
+[![Build Status](https://travis-ci.org/01org/camera-streaming-daemon.svg?branch=master)](https://travis-ci.org/01org/camera-streaming-daemon)
+
 ### Compilation and installation ###
 
 In order to compile you need the following packages:


### PR DESCRIPTION
Using docker with a more recent version of Ubuntu, so we do not need to
maintain a long list of tasks to setup the environment needed to build
Camera Streaming Daemon.

~~Next step: create a custom image with the dependencies installed, so we
will be able to remove the time-consuming apt-get step.~~