### PR TITLE
README: Update versions in requirements list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 In order to compile you need the following packages:
 
-  - GCC compiler
+  - GCC/G++ compiler 5 or newer
   - C and C++ standard libraries
   - GLib 2.44 or greater (https://wiki.gnome.org/Projects/GLib)
   - Avahi 0.6 or newer (https://github.com/lathiat/avahi)
-  - GStreamer 1.10 or newer (https://gstreamer.freedesktop.org/)
-  - GStreamer RTSP Server 1.10 or newer (https://gstreamer.freedesktop.org/modules/gst-rtsp-server.html)
+  - GStreamer 1.8.3 or newer (https://gstreamer.freedesktop.org/)
+  - GStreamer RTSP Server 1.8.3 or newer (https://gstreamer.freedesktop.org/modules/gst-rtsp-server.html)
 
 #### Build ####
 


### PR DESCRIPTION
While building on Ubuntu 16.04, I found the minimum version of gstreamer & friends needed is 1.8.3.
Also, add info about gcc/g++ versions.