### PR TITLE
stream_builder: Fix an invalid static object access

### DIFF
--- a/src/stream_builder.cpp
+++ b/src/stream_builder.cpp
@@ -20,19 +20,24 @@
 
 #include "stream_builder.h"
 
-std::vector<StreamBuilder *> StreamBuilder::builders;
-
 StreamBuilder::StreamBuilder()
 {
-    builders.push_back(this);
+    get_builders().push_back(this);
 }
 
 StreamBuilder::~StreamBuilder()
 {
     StreamBuilder *b = this;
+    std::vector<StreamBuilder *> &builders = get_builders();
     std::vector<StreamBuilder *>::iterator it = std::find(builders.begin(), builders.end(), b);
     if (it != builders.end()) {
         std::swap(*it, builders.back());
         builders.pop_back();
     }
+}
+
+std::vector<StreamBuilder *> &StreamBuilder::get_builders()
+{
+    static std::vector<StreamBuilder *> builders;
+    return builders;
 }

--- a/src/stream_builder.h
+++ b/src/stream_builder.h
@@ -22,11 +22,11 @@ class StreamBuilder {
 public:
     virtual std::vector<Stream *> build_streams() = 0;
     virtual ~StreamBuilder();
+    static std::vector<StreamBuilder *> &get_builders();
 
 protected:
     StreamBuilder();
 
 private:
-    static std::vector<StreamBuilder *> builders;
     friend class StreamManager;
 };

--- a/src/stream_manager.cpp
+++ b/src/stream_manager.cpp
@@ -42,11 +42,12 @@ void StreamManager::start()
         return;
     is_running = true;
 
-    for (StreamBuilder *builder : StreamBuilder::builders)
+    for (StreamBuilder *builder : StreamBuilder::get_builders())
         for (Stream *s : builder->build_streams()) {
             log_debug("Adding stream %s (%s)", s->get_path().c_str(), s->get_name().c_str());
             streams.emplace_back(std::unique_ptr<Stream>{s});
         }
+    StreamBuilder::get_builders().clear();
 
     rtsp_server.start();
     avahi_publisher.start();


### PR DESCRIPTION
The current code has a problem in the initialization order of static
objects.
It is not correct to assume that all static objects of a class will be
initialized before another element of that class is accessed. So it is
not safe to access an static object from a class in an object that is
also static.
To fix that, instead of accessing the builders object directly, we're
using a get_builders method that ensures the builders object is created
when it is called.