### PR TITLE
mavlink: Initialize _timeout_handler variable

### DIFF
--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -30,6 +30,7 @@
 MavlinkServer::MavlinkServer(std::vector<std::unique_ptr<Stream>> &streams)
     : _streams(streams)
     , _is_running(false)
+    , _timeout_handler(0)
 {
 }
 
@@ -133,7 +134,8 @@ void MavlinkServer::stop()
         return;
     _is_running = false;
 
-    Mainloop::get_mainloop()->del_timeout(_timeout_handler);
+    if (_timeout_handler > 0)
+        Mainloop::get_mainloop()->del_timeout(_timeout_handler);
 }
 
 int MavlinkServer::_get_system_id()


### PR DESCRIPTION
Variable was not initialized in mavlink_server class.