### PR TITLE
Makefile: Add options to disable/enable mavlink and avhai supports

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,18 +12,13 @@ AM_MAKEFLAGS = --no-print-directory
 GCC_COLORS ?= 'yes'
 export GCC_COLORS
 
-BUILT_SOURCES = include/mavlink/ardupilotmega/mavlink.h
+BUILT_SOURCES =
+samples_deps =
 
 clean-local:
 	rm -rf $(top_builddir)/include/mavlink
 	rm -rf $(EXTRA_PROGRAMS)
 
-include/mavlink/ardupilotmega/mavlink.h: modules/mavlink/pymavlink/tools/mavgen.py modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
-	$(AM_V_GEN)$(PYTHON) $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
-		-o include/mavlink \
-		--lang C \
-		--wire-protocol 2.0 \
-		$(srcdir)/modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
 #if SYSTEMD
 systemdsystemunitdir = @SYSTEMD_SYSTEMUNITDIR@
 systemdsystemunit_DATA = csd.service
@@ -32,8 +27,6 @@ systemdsystemunit_DATA = csd.service
 
 AM_CPPFLAGS = \
 	-include $(abs_top_builddir)/config.h \
-	-I$(abs_top_builddir)/include/mavlink \
-	-I$(abs_top_builddir)/include/mavlink/ardupilotmega \
 	-DSYSCONFDIR=\""$(sysconfdir)"\"
 
 AM_CFLAGS = \
@@ -77,7 +70,6 @@ AM_CFLAGS = \
 	-fvisibility=hidden \
 	-ffunction-sections \
 	-fdata-sections \
-	${AVAHI_CFLAGS} \
 	${GST_CFLAGS}
 
 AM_CXXFLAGS = \
@@ -118,7 +110,6 @@ AM_CXXFLAGS = \
 	-fvisibility=hidden \
 	-ffunction-sections \
 	-fdata-sections \
-	${AVAHI_CFLAGS} \
 	${GST_CFLAGS}
 
 AM_LDFLAGS = \
@@ -127,8 +118,6 @@ AM_LDFLAGS = \
 	-Wl,--gc-sections
 
 BASE_FILES = \
-	src/avahi_publisher.cpp \
-	src/avahi_publisher.h \
 	src/conf_file.cpp \
 	src/conf_file.h \
 	src/glib_mainloop.cpp \
@@ -140,8 +129,6 @@ BASE_FILES = \
 	src/macro.h \
 	src/mainloop.cpp \
 	src/mainloop.h \
-	src/mavlink_server.cpp \
-	src/mavlink_server.h \
 	src/pollable.cpp \
 	src/pollable.h \
 	src/rtsp_server.cpp \
@@ -183,16 +170,14 @@ csd_SOURCES = \
 	${BASE_FILES} \
 	src/main.cpp
 
-csd_LDADD = $(GLIB_LIBS) $(AVAHI_LIBS) $(GST_LIBS)
+csd_LDADD = $(GLIB_LIBS) $(GST_LIBS)
 
 CLEANFILES += csd.service
 
 #Samples
-EXTRA_PROGRAMS = samples/camera-sample-custom samples/camera-sample-client samples/camera-sample-mavlink-client
+EXTRA_PROGRAMS = samples/camera-sample-custom
 
 samples_camera_sample_custom_LDADD = ${csd_LDADD}
-samples_camera_sample_client_LDADD = $(GLIB_LIBS) $(AVAHI_LIBS)
-samples_camera_sample_mavlink_client_LDADD = $(GLIB_LIBS) $(AVAHI_LIBS)
 
 samples_camera_sample_custom_SOURCES = \
 	$(BASE_FILES) \
@@ -202,6 +187,16 @@ samples_camera_sample_custom_SOURCES = \
 	samples/stream_custom.cpp \
 	samples/stream_custom.h
 
+if !DISABLE_AVAHI
+EXTRA_PROGRAMS += samples/camera-sample-client
+BASE_FILES += \
+	src/avahi_publisher.cpp \
+	src/avahi_publisher.h
+
+AM_CXXFLAGS += ${AVAHI_CFLAGS}
+AM_CXXFLAGS += ${AVAHI_CFLAGS}
+csd_LDADD += $(AVAHI_LIBS)
+
 samples_camera_sample_client_SOURCES = \
 	samples/main_sample_client.cpp \
 	src/log.cpp \
@@ -210,6 +205,29 @@ samples_camera_sample_client_SOURCES = \
 	src/glib_mainloop.h \
 	src/mainloop.cpp \
 	src/mainloop.h
+
+samples_camera_sample_client_LDADD = $(GLIB_LIBS) $(AVAHI_LIBS)
+endif
+
+if ENABLE_MAVLINK
+
+EXTRA_PROGRAMS += samples/camera-sample-mavlink-client
+
+BUILT_SOURCES += include/mavlink/ardupilotmega/mavlink.h
+include/mavlink/ardupilotmega/mavlink.h: modules/mavlink/pymavlink/tools/mavgen.py modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
+	$(AM_V_GEN)$(PYTHON) $(srcdir)/modules/mavlink/pymavlink/tools/mavgen.py \
+		-o include/mavlink \
+		--lang C \
+		--wire-protocol 2.0 \
+		$(srcdir)/modules/mavlink/message_definitions/v1.0/ardupilotmega.xml
+
+AM_CPPFLAGS += \
+	-I$(abs_top_builddir)/include/mavlink \
+	-I$(abs_top_builddir)/include/mavlink/ardupilotmega
+
+BASE_FILES += \
+	src/mavlink_server.cpp \
+	src/mavlink_server.h
 
 samples_camera_sample_mavlink_client_SOURCES = \
 	samples/main_sample_mavlink_client.cpp \
@@ -226,10 +244,17 @@ samples_camera_sample_mavlink_client_SOURCES = \
 	src/util.c \
 	src/util.h
 
-.PHONY: samples
-samples: include/mavlink/ardupilotmega/mavlink.h
-	$(MAKE) $(EXTRA_PROGRAMS)
+samples_camera_sample_mavlink_client_LDADD = $(GLIB_LIBS)
+if !DISABLE_AVAHI
+samples_camera_sample_mavlink_client_LDADD += $(AVAHI_LIBS)
+endif
 
+samples_deps = samples_camera_sample_mavlink_client_LDADD
+endif
+
+.PHONY: samples
+samples: $(samples_deps)
+	$(MAKE) $(EXTRA_PROGRAMS)
 
 # ------------------------------------------------------------------------------
 # coverity

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,23 @@ AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_SEARCH_LIBS([rs_create_context], [realsense], [AM_CONDITIONAL([HAVE_REALSENSE], true)], [AM_CONDITIONAL([HAVE_REALSENSE], false)])
 
+AC_ARG_ENABLE([mavlink],
+ AS_HELP_STRING([--enable-mavlink], [Enable MAVLink advertisement]),
+ [
+   AM_CONDITIONAL([ENABLE_MAVLINK], true)
+   AC_DEFINE(ENABLE_MAVLINK, 1, [Enable MAVLink advertisement])
+ ],
+ [AM_CONDITIONAL([ENABLE_MAVLINK], false)])
+
+AC_ARG_ENABLE([avahi],
+ AS_HELP_STRING([--disable-avahi], [Disable avahi advertisement]),
+ [
+   AM_CONDITIONAL([DISABLE_AVAHI], true)
+   AC_DEFINE(DISABLE_AVAHI, 1, [Disable avahi advertisement])
+ ],
+ [AM_CONDITIONAL([DISABLE_AVAHI], false)])
+
+
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
 AC_PREFIX_DEFAULT([/usr])

--- a/src/avahi_publisher.cpp
+++ b/src/avahi_publisher.cpp
@@ -146,6 +146,7 @@ void AvahiPublisher::publish_services(AvahiClient *c)
 
 void AvahiPublisher::start()
 {
+    log_error("AVAHI START\n");
     if (is_running)
         return;
 

--- a/src/glib_mainloop.cpp
+++ b/src/glib_mainloop.cpp
@@ -52,7 +52,9 @@ static void setup_signal_handlers()
 }
 
 GlibMainloop::GlibMainloop()
+#ifndef DISABLE_AVAHI
     : avahi_poll(nullptr)
+#endif
 {
     gmainloop = g_main_loop_new(NULL, FALSE);
     mainloop = this;
@@ -62,10 +64,12 @@ GlibMainloop::GlibMainloop()
 GlibMainloop::~GlibMainloop()
 {
     mainloop = nullptr;
+#ifndef DISABLE_AVAHI
     if (avahi_poll) {
         avahi_glib_poll_free(avahi_poll);
         avahi_poll = nullptr;
     }
+#endif
 
     g_main_loop_unref(gmainloop);
     gmainloop = nullptr;
@@ -76,12 +80,14 @@ void GlibMainloop::loop()
     g_main_loop_run(gmainloop);
 }
 
+#ifndef DISABLE_AVAHI
 const AvahiPoll *GlibMainloop::get_avahi_poll_api()
 {
     if (!avahi_poll)
         avahi_poll = avahi_glib_poll_new(NULL, G_PRIORITY_DEFAULT);
     return avahi_glib_poll_get(avahi_poll);
 }
+#endif
 
 void GlibMainloop::quit()
 {

--- a/src/glib_mainloop.h
+++ b/src/glib_mainloop.h
@@ -17,7 +17,9 @@
  */
 #pragma once
 
+#ifndef DISABLE_AVAHI
 #include <avahi-glib/glib-watch.h>
+#endif
 #include <vector>
 
 #include "mainloop.h"
@@ -28,7 +30,9 @@ public:
     ~GlibMainloop();
     void loop() override;
     void quit() override;
+#ifndef DISABLE_AVAHI
     const AvahiPoll *get_avahi_poll_api() override;
+#endif
 
     unsigned int add_timeout(unsigned int timeout_msec, bool (*cb)(void *),
                              const void *data) override;
@@ -36,6 +40,8 @@ public:
     int add_fd(int fd, int flags, bool (*cb)(const void *data, int flags), const void *data) override;
     void remove_fd(int handler) override;
 
+#ifndef DISABLE_AVAHI
 private:
     AvahiGLibPoll *avahi_poll;
+#endif
 };

--- a/src/mainloop.h
+++ b/src/mainloop.h
@@ -17,13 +17,17 @@
  */
 #pragma once
 
+#ifndef DISABLE_AVAHI
 #include <avahi-common/watch.h>
+#endif
 #include <functional>
 
 class Mainloop {
 public:
     virtual void loop() = 0;
+#ifndef DISABLE_AVAHI
     virtual const AvahiPoll *get_avahi_poll_api() = 0;
+#endif
     static Mainloop *get_mainloop() { return mainloop; };
     virtual unsigned int add_timeout(unsigned int timeout_msec, bool (*cb)(void *),
                                      const void *data) = 0;

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -282,6 +282,7 @@ bool _heartbeat_cb(void *data)
 
 void MavlinkServer::start()
 {
+    log_error("MAVLINK START\n");
     if (_is_running)
         return;
     _is_running = true;

--- a/src/stream_manager.cpp
+++ b/src/stream_manager.cpp
@@ -29,9 +29,13 @@
 
 StreamManager::StreamManager(ConfFile &conf)
     : is_running(false)
+#ifndef DISABLE_AVAHI
     , avahi_publisher(streams, DEFAULT_SERVICE_PORT, DEFAULT_SERVICE_TYPE)
+#endif
     , rtsp_server(streams, DEFAULT_SERVICE_PORT)
+#ifdef ENABLE_MAVLINK
     , mavlink_server(conf, streams, rtsp_server)
+#endif
 {
     GstreamerPipelineBuilder::get_instance().apply_configs(conf);
     for (StreamBuilder *builder : StreamBuilder::get_builders())
@@ -54,8 +58,12 @@ void StreamManager::start()
     is_running = true;
 
     rtsp_server.start();
+#ifndef DISABLE_AVAHI
     avahi_publisher.start();
+#endif
+#ifdef ENABLE_MAVLINK
     mavlink_server.start();
+#endif
 }
 
 void StreamManager::stop()
@@ -64,9 +72,13 @@ void StreamManager::stop()
         return;
     is_running = false;
 
-    avahi_publisher.stop();
     rtsp_server.stop();
+#ifndef DISABLE_AVAHI
+    avahi_publisher.stop();
+#endif
+#ifdef ENABLE_MAVLINK
     mavlink_server.stop();
+#endif
 }
 
 void StreamManager::addStream(Stream *stream)

--- a/src/stream_manager.h
+++ b/src/stream_manager.h
@@ -22,9 +22,13 @@
 #include <string>
 #include <vector>
 
+#ifndef DISABLE_AVAHI
 #include "avahi_publisher.h"
+#endif
 #include "conf_file.h"
+#ifdef ENABLE_MAVLINK
 #include "mavlink_server.h"
+#endif
 #include "rtsp_server.h"
 #include "stream.h"
 
@@ -39,7 +43,11 @@ public:
 private:
     std::vector<std::unique_ptr<Stream>> streams;
     bool is_running;
+#ifndef DISABLE_AVAHI
     AvahiPublisher avahi_publisher;
+#endif
     RTSPServer rtsp_server;
+#ifdef ENABLE_MAVLINK
     MavlinkServer mavlink_server;
+#endif
 };


### PR DESCRIPTION
Add flag --enable-mavlink to enable mavlink support on CSD (default is
not disabled).
Add flag --disable-avahi to disable avahi support on CSD (default is
enabled).