### PR TITLE
Socket: fix memory leak

### DIFF
--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -85,6 +85,7 @@ bool Socket::_can_read()
         read_buf.len = (unsigned int)r;
         _read_cb(read_buf, sockaddr);
     }
+    delete[] read_buf.data;
     return true;
 }
 


### PR DESCRIPTION
Also need memory deallocation before return (if error) in _can_read and _can_write.