### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The first step to build the samples:
 
 And then in a computer connected to the target drone using WiFi or any other Ethernet connection:
 
-    $ ./samples/camera-sample-mavlink-client
+    $ ./samples/camera-sample-client
 
 More information about the camera-sample-mavlink-client is located in [[samples|Samples#camera-sample-mavlink-client]] wiki page.
 


### PR DESCRIPTION
Update the `camera-sample-client` file name in README.md file. After `make samples`, only two executables can be found in the samples folder (`camera-sample-client` and `camera-sample-custom`). There's no executable named `camera-sample-mavlink-client`. So maybe the readme file is out-of-date on the executable name.