### PR TITLE
Add support for Camera Control

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -237,7 +237,8 @@ BASE_FILES += \
 	src/mavlink_server.cpp \
 	src/mavlink_server.h \
 	src/CameraParameters.cpp \
-	src/CameraParameters.h
+	src/CameraParameters.h \
+	src/CameraComponent.h
 
 samples_camera_sample_mavlink_client_SOURCES = \
 	samples/main_sample_mavlink_client.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -238,7 +238,9 @@ BASE_FILES += \
 	src/mavlink_server.h \
 	src/CameraParameters.cpp \
 	src/CameraParameters.h \
-	src/CameraComponent.h
+	src/CameraComponent.h \
+	src/CameraComponent_V4L2.cpp \
+	src/CameraComponent_V4L2.h
 
 samples_camera_sample_mavlink_client_SOURCES = \
 	samples/main_sample_mavlink_client.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -240,7 +240,9 @@ BASE_FILES += \
 	src/CameraParameters.h \
 	src/CameraComponent.h \
 	src/CameraComponent_V4L2.cpp \
-	src/CameraComponent_V4L2.h
+	src/CameraComponent_V4L2.h \
+	src/CameraServer.cpp \
+	src/CameraServer.h
 
 samples_camera_sample_mavlink_client_SOURCES = \
 	samples/main_sample_mavlink_client.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -146,7 +146,9 @@ BASE_FILES = \
 	src/stream_manager.cpp \
 	src/stream_manager.h \
 	src/util.c \
-	src/util.h
+	src/util.h \
+	src/v4l2_interface.cpp \
+	src/v4l2_interface.h
 
 if HAVE_REALSENSE
 BASE_FILES += \

--- a/Makefile.am
+++ b/Makefile.am
@@ -235,7 +235,9 @@ AM_CPPFLAGS += \
 
 BASE_FILES += \
 	src/mavlink_server.cpp \
-	src/mavlink_server.h
+	src/mavlink_server.h \
+	src/CameraParameters.cpp \
+	src/CameraParameters.h
 
 samples_camera_sample_mavlink_client_SOURCES = \
 	samples/main_sample_mavlink_client.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -219,6 +219,19 @@ samples_camera_sample_client_SOURCES = \
 samples_camera_sample_client_LDADD = $(GLIB_LIBS) $(AVAHI_LIBS)
 endif
 
+EXTRA_PROGRAMS += samples/camera-params-client
+
+samples_camera_params_client_SOURCES = \
+        src/CameraParameters.cpp \
+        src/CameraParameters.h \
+        samples/main_sample_camparams_client.cpp \
+        src/log.cpp \
+        src/log.h \
+        src/util.c \
+        src/util.h
+
+samples_camera_params_client_LDADD = $(GLIB_LIBS)
+
 if ENABLE_MAVLINK
 
 EXTRA_PROGRAMS += samples/camera-sample-mavlink-client

--- a/samples/camera-def-rs-rgb.xml
+++ b/samples/camera-def-rs-rgb.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<mavlinkcamera>
+    <definition version="1">
+        <model>RealSense RGB Camera</model>
+        <vendor>Intel Corporation</vendor>
+    </definition>
+    <parameters>
+        <!-- control = 0 tells us this should not create an automatic UI control -->
+        <parameter name="camera-mode" type="uint32" default="1" control="0">
+            <description>Camera Mode</description>
+            <options>
+                <option name="still" value="0">
+                    <exclusions>
+                        <exclude>video-size</exclude>
+                    </exclusions>
+                </option>
+                <option name="video" value="1">
+                </option>
+            </options>
+        </parameter>
+        <parameter name="brightness" type="uint32" default="56" min="0" max="225" step ="1">
+            <description>Brightness</description>
+        </parameter>
+        <parameter name="contrast" type="uint32" default="32" min="16" max="64" step ="1">
+            <description>Contrast</description>
+        </parameter>
+        <parameter name="saturation" type="uint32" default="128" min="0" max="225" step ="1">
+            <description>Saturation</description>
+        </parameter>
+        <parameter name="hue" type="int32" default="0" min="-2200" max="2200" step ="1">
+            <description>Hue</description>
+        </parameter>
+        <parameter name="gamma" type="uint32" default="220" min="100" max="280" step ="1">
+            <description>Gamma</description>
+        </parameter>
+        <parameter name="gain" type="uint32" default="32" min="0" max="256" step ="1">
+            <description>Gain</description>
+        </parameter>
+        <parameter name="sharpness" type="uint32" default="0" min="0" max="7" step ="1">
+            <description>Sharpness </description>
+        </parameter>
+        <parameter name="backlight" type="uint32" default="1" min="0" max="4" step ="1">
+            <description>Backlight Compensation</description>
+        </parameter>
+        <parameter name="power-mode" type="uint32" default="0">
+            <description>Power Line Frequency </description>
+            <options>
+                <option name="Disabled" value="0" />
+                <option name="50 Hz" value="1" />
+                <option name="60 Hz" value="2" />
+            </options>
+        </parameter>
+        <parameter name="wb-mode" type="uint32" default="1">
+            <description>White Balance Mode</description>
+            <options>
+                <option name="Manual Mode" value="0" />
+                <option name="Auto" value="1" >
+                <exclusions>
+                    <exclude>wb-temp</exclude>
+                </exclusions>
+                </option>
+            </options>
+        </parameter>
+        <parameter name="wb-temp" type="uint32" default="6500" min="2000" max="8000" step ="1">
+            <description>White Balance Temperature </description>
+        </parameter>
+        <parameter name="exp-mode" type="uint32" default="3">
+            <description>Exposure Mode</description>
+            <options>
+                <option name="Manual Mode" value="0" />
+                <option name="Aperture Priority Mode" value="3" >
+                <exclusions>
+                    <exclude>exp-absolute</exclude>
+                </exclusions>
+                </option>
+            </options>
+        </parameter>
+        <parameter name="exp-absolute" type="uint32" default="1" min="1" max="666" step ="1">
+            <description>Exposure Absolute</description>
+        </parameter>
+        <parameter name="video-size" type="uint32" default="0">
+            <description>Video Resolution</description>
+            <options>
+                <option name="1920x1080x30" value="1" />
+                <option name="1920x1080x15" value="2" />
+                <option name="1280x720x30"  value="3" />
+                <option name="1280x720x15"  value="4" />
+                <option name="960x540x30"   value="5" />
+                <option name="960x540x15"   value="6" />
+                <option name="848x480x30"   value="7" />
+                <option name="848x480x15"   value="8" />
+                <option name="640x480x60"   value="9" />
+                <option name="640x480x30"   value="10" />
+                <option name="640x480x15"   value="11" />
+                <option name="640x360x30"   value="12" />
+                <option name="640x360x15"   value="13" />
+                <option name="424x240x30"   value="14" />
+                <option name="424x240x15"   value="15" />
+                <option name="320x240x60"   value="16" />
+                <option name="320x240x30"   value="17" />
+                <option name="320x240x15"   value="18" />
+                <option name="320x180x30"   value="19" />
+                <option name="320x180x15"   value="20" />
+            </options>
+        </parameter>
+    </parameters>
+</mavlinkcamera>

--- a/samples/main_sample_camparams_client.cpp
+++ b/samples/main_sample_camparams_client.cpp
@@ -1,0 +1,226 @@
+/*
+ * This file is part of the Camera Streaming Daemon project
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+#include <bitset>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "CameraParameters.h"
+#include "log.h"
+#include "util.h"
+
+CameraParameters camParam;
+
+void print_param_type()
+{
+    // std::cout << "PARAM_TYPE_UINT8  : 1" << std::endl;
+    // std::cout << "PARAM_TYPE_INT8   : 2" << std::endl;
+    // std::cout << "PARAM_TYPE_UINT16 : 3" << std::endl;
+    // std::cout << "PARAM_TYPE_INT16  : 4" << std::endl;
+    std::cout << "PARAM_TYPE_UINT32 : 5" << std::endl;
+    // std::cout << "PARAM_TYPE_INT32  : 6" << std::endl;
+    // std::cout << "PARAM_TYPE_UINT64 : 7" << std::endl;
+    // std::cout << "PARAM_TYPE_UINT64 : 8" << std::endl;
+    std::cout << "PARAM_TYPE_REAL32 : 9" << std::endl;
+    // std::cout << "PARAM_TYPE_REAL64 : 10" << std::endl;
+
+    return;
+}
+
+void print_usage()
+{
+    std::cout << "0:  EXIT" << std::endl;
+    std::cout << "1:  Test Set-Get" << std::endl;
+    std::cout << "2:  Set Param" << std::endl;
+    std::cout << "3:  Get Param" << std::endl;
+    std::cout << "99: Test uint32<->string conversion" << std::endl;
+    return;
+}
+
+// uint32(data type) -> byte array(to transmit) -> string(to store) -> byte array -> uint32
+void test_convert_logic(uint32_t value)
+{
+    log_debug("Set DataType value: %d", value);
+
+    // 1. Convert type uint32 to byte array
+    CameraParameters::cam_param_union_t u;
+    u.param_uint32 = value;
+    log_debug("Set ByteArray value:");
+    for (int i = 0; i < CAM_PARAM_VALUE_LEN; i++)
+        printf("0x%.2x ", u.bytes[i]);
+    printf("\n");
+
+    // 2. Convert byte array to string
+    std::string str(reinterpret_cast<char const *>(u.bytes), CAM_PARAM_VALUE_LEN);
+    log_debug("Stored as String Object");
+
+    // 3. Convert string to byte array
+    // const char *arr2 = str.c_str();
+    uint8_t arr[CAM_PARAM_VALUE_LEN];
+    mem_cpy(arr, sizeof(arr), str.data(), str.size(), sizeof(arr));
+    log_debug("Get ByteArray value:");
+    for (int i = 0; i < CAM_PARAM_VALUE_LEN; i++)
+        printf("0x%.2x ", arr[i]);
+    printf("\n");
+
+    // 4. Convert byte array to type uint32
+    CameraParameters::cam_param_union_t u2;
+    mem_cpy(u2.bytes, sizeof(u2.bytes), arr, sizeof(arr), sizeof(u2.bytes));
+    log_debug("Get DataType value: %d", u2.param_uint32);
+    if (u2.param_uint32 != u.param_uint32)
+        log_error("Error in logic:%d", value);
+}
+
+void input_param_id(std::string &paramID)
+{
+    std::cout << "Enter Parameter ID String" << std::endl;
+    std::cin >> paramID;
+}
+
+void input_param_value(CameraParameters::cam_param_union_t &u)
+{
+    std::cout << "Enter Parameter Type" << std::endl;
+    print_param_type();
+    scanf("%d", &u.type);
+    std::cout << "Enter Parameter Value ";
+    switch (u.type) {
+    case CameraParameters::PARAM_TYPE_REAL32:
+        std::cout << "Float :" << std::endl;
+        std::cin >> u.param_float;
+        break;
+    case CameraParameters::PARAM_TYPE_UINT32:
+        std::cout << "Uint32 :" << std::endl;
+        std::cin >> u.param_uint32;
+        break;
+    default:
+        std::cout << "Unsup Type:" << u.type << std::endl;
+        break;
+    }
+
+    return;
+}
+
+int set(std::string paramID)
+{
+    CameraParameters::cam_param_union_t u;
+    input_param_value(u);
+    switch (u.type) {
+    case CameraParameters::PARAM_TYPE_REAL32:
+        log_debug("SET Param: %s Value: %f", paramID.c_str(), u.param_float);
+        camParam.setParameter(paramID, u.param_float);
+        break;
+    case CameraParameters::PARAM_TYPE_UINT32:
+        log_debug("SET Param: %s Value: %d", paramID.c_str(), u.param_uint32);
+        camParam.setParameter(paramID, u.param_uint32);
+        break;
+    default:
+        std::cout << "Unsupported Type" << std::endl;
+        break;
+    }
+
+    return u.type;
+}
+
+void get(std::string paramID, int type)
+{
+    std::string paramValue;
+    CameraParameters::cam_param_union_t u;
+    paramValue = camParam.getParameter(paramID);
+    if (paramValue.empty()) {
+        log_error("No Parameter found");
+        return;
+    }
+    mem_cpy(u.bytes, sizeof(u.bytes), paramValue.data(), paramValue.size(), sizeof(u.bytes));
+    switch (type) {
+    case CameraParameters::PARAM_TYPE_REAL32:
+        log_debug("GET Param: %s Value: %f", paramID.c_str(), u.param_float);
+        break;
+    case CameraParameters::PARAM_TYPE_UINT32:
+        log_debug("GET Param: %s Value: %d", paramID.c_str(), u.param_uint32);
+        break;
+    default:
+        break;
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    Log::open();
+    Log::set_max_level(Log::Level::DEBUG);
+    log_debug("Camera Parameters Client");
+
+    // print usage
+    print_usage();
+    // provide options to user
+    int input = 0;
+    while (1) {
+        std::cout << "Please enter selection or enter 0 to exit :" << std::endl;
+        std::cin >> input;
+        switch (input) {
+        case 0:
+            std::cout << "Exiting the program..." << std::endl;
+            exit(0);
+            break;
+        case 1: {
+            std::cout << "Test Set/Get Operation" << std::endl;
+            std::string paramID;
+            std::string paramValue;
+            int type;
+            input_param_id(paramID);
+            type = set(paramID);
+            get(paramID, type);
+            break;
+        }
+        case 2: {
+            std::cout << "Set Parameter" << std::endl;
+            std::string paramID;
+            input_param_id(paramID);
+            set(paramID);
+            break;
+        }
+        case 3: {
+            std::cout << "Get Parameter" << std::endl;
+            std::string paramID;
+            input_param_id(paramID);
+            std::string value = camParam.getParameter(paramID);
+            if (value.empty())
+                std::cout << "Parameter undefined" << std::endl;
+            std::cout << paramID << " Value:" << value << std::endl;
+            break;
+        }
+        case 99: {
+            uint32_t value;
+            std::cout << "Test DataType<->String Conversion Logic" << std::endl;
+            std::cout << "Please enter number to use for conversion:" << std::endl;
+            std::cin >> value;
+            test_convert_logic(value);
+        }
+        default:
+            break;
+        }
+    }
+
+    // for(uint32_t i =0; i< 4294967295; i++)
+    // test_convert_logic(i);
+    // log_debug("Test Done\n");
+
+    Log::close();
+    return 0;
+}

--- a/samples/main_sample_mavlink_client.cpp
+++ b/samples/main_sample_mavlink_client.cpp
@@ -165,7 +165,7 @@ static void handle_mavlink_message(struct Context &ctx, const struct sockaddr_in
         mavlink_camera_information_t info;
         mavlink_msg_camera_information_decode(&msg, &info);
 
-        ctx.streams[ctx.streams_size].id = info.camera_id;
+        ctx.streams[ctx.streams_size].id = msg.compid;
         ctx.streams[ctx.streams_size++].name = strdup((const char *)info.model_name);
     } else if (msg.msgid == MAVLINK_MSG_ID_VIDEO_STREAM_INFORMATION) {
         char cmd[300];

--- a/src/CameraComponent.h
+++ b/src/CameraComponent.h
@@ -57,11 +57,12 @@ public:
     const CameraInfo &getCameraInfo() const { return camInfo; }
     const StorageInfo &getStorageInfo() const { return storeInfo; }
     const std::map<std::string, std::string> &getParamList() { return camParam.getParameterList(); }
-    virtual int getParam(const char *param_id, char *param_value, size_t value_size) = 0;
-    virtual int setParam(const char *param_id, const char *param_value, size_t value_size,
-                         int param_type)
+    virtual int getParamType(const char *param_id, size_t id_size) = 0;
+    virtual int getParam(const char *param_id, size_t id_size, char *param_value, size_t value_size)
         = 0;
-    int getParamType(const char *param_id) { return camParam.getParameterType(param_id); }
+    virtual int setParam(const char *param_id, size_t id_size, const char *param_value,
+                         size_t value_size, int param_type)
+        = 0;
     virtual int setCameraMode(uint32_t mode) = 0;
     virtual int getCameraMode() = 0;
 protected:

--- a/src/CameraComponent.h
+++ b/src/CameraComponent.h
@@ -52,7 +52,6 @@ struct StorageInfo {
 
 class CameraComponent {
 public:
-    CameraComponent() {}
     virtual ~CameraComponent() {}
     const CameraInfo &getCameraInfo() const { return camInfo; }
     const StorageInfo &getStorageInfo() const { return storeInfo; }

--- a/src/CameraComponent.h
+++ b/src/CameraComponent.h
@@ -40,7 +40,6 @@ struct CameraInfo {
 };
 
 struct StorageInfo {
-    uint32_t time_boot_ms;
     uint8_t storage_id;
     uint8_t storage_count;
     uint8_t status;
@@ -58,8 +57,10 @@ public:
     const CameraInfo &getCameraInfo() const { return camInfo; }
     const StorageInfo &getStorageInfo() const { return storeInfo; }
     const std::map<std::string, std::string> &getParamList() { return camParam.getParameterList(); }
-    virtual int getParam(const char *param_id, char *param_value) = 0;
-    virtual int setParam(const char *param_id, const char *param_value, int param_type) = 0;
+    virtual int getParam(const char *param_id, char *param_value, size_t value_size) = 0;
+    virtual int setParam(const char *param_id, const char *param_value, size_t value_size,
+                         int param_type)
+        = 0;
     int getParamType(const char *param_id) { return camParam.getParameterType(param_id); }
 
 protected:

--- a/src/CameraComponent.h
+++ b/src/CameraComponent.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <gst/gst.h>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "CameraParameters.h"
+#include "log.h"
+
+struct CameraInfo {
+    uint8_t vendorName[32];
+    uint8_t modelName[32];
+    uint32_t firmware_version;
+    float focal_length;
+    float sensor_size_h;
+    float sensor_size_v;
+    uint16_t resolution_h;
+    uint16_t resolution_v;
+    uint8_t lens_id;
+    uint32_t flags;
+    uint16_t cam_definition_version;
+    char cam_definition_uri[140];
+};
+
+struct StorageInfo {
+    uint32_t time_boot_ms;
+    uint8_t storage_id;
+    uint8_t storage_count;
+    uint8_t status;
+    float total_capacity;
+    float used_capacity;
+    float available_capacity;
+    float read_speed;
+    float write_speed;
+};
+
+class CameraComponent {
+public:
+    CameraComponent() {}
+    virtual ~CameraComponent() {}
+    const CameraInfo &getCameraInfo() const { return camInfo; }
+    const StorageInfo &getStorageInfo() const { return storeInfo; }
+    const std::map<std::string, std::string> &getParamList() { return camParam.getParameterList(); }
+    virtual int getParam(const char *param_id, char *param_value) = 0;
+    virtual int setParam(const char *param_id, const char *param_value, int param_type) = 0;
+    int getParamType(const char *param_id) { return camParam.getParameterType(param_id); }
+
+protected:
+    CameraInfo camInfo;
+    StorageInfo storeInfo;
+    CameraParameters camParam;
+};

--- a/src/CameraComponent.h
+++ b/src/CameraComponent.h
@@ -62,7 +62,8 @@ public:
                          int param_type)
         = 0;
     int getParamType(const char *param_id) { return camParam.getParameterType(param_id); }
-
+    virtual int setCameraMode(uint32_t mode) = 0;
+    virtual int getCameraMode() = 0;
 protected:
     CameraInfo camInfo;
     StorageInfo storeInfo;

--- a/src/CameraComponent_V4L2.cpp
+++ b/src/CameraComponent_V4L2.cpp
@@ -291,9 +291,15 @@ int CameraComponent_V4L2::setParam(std::string param_id, uint8_t param_value)
     return 0;
 }
 
-int CameraComponent_V4L2::setCameraMode(uint32_t param_value)
+int CameraComponent_V4L2::setCameraMode(uint32_t mode)
 {
+    mCamMode = mode;
     return 0;
+}
+
+int CameraComponent_V4L2::getCameraMode()
+{
+    return mCamMode;
 }
 
 int CameraComponent_V4L2::setImazeSize(uint32_t param_value)

--- a/src/CameraComponent_V4L2.cpp
+++ b/src/CameraComponent_V4L2.cpp
@@ -91,14 +91,13 @@ void CameraComponent_V4L2::initSupportedValues()
 void CameraComponent_V4L2::initDefaultValues()
 {
     // TODO :: Get the details of the default values from the camera device and then save it in DB
-    saveParameter(CameraParameters::CAMERA_MODE,
-                  (uint32_t)CameraParameters::id_camera_mode::ID_CAMERA_MODE_VIDEO);
+    saveParameter(CameraParameters::CAMERA_MODE, (uint32_t)CameraParameters::ID_CAMERA_MODE_VIDEO);
     saveParameter(CameraParameters::BRIGHTNESS, (uint32_t)56);
     saveParameter(CameraParameters::CONTRAST, (uint32_t)32);
     saveParameter(CameraParameters::SATURATION, (uint32_t)128);
     saveParameter(CameraParameters::HUE, (int32_t)0);
     saveParameter(CameraParameters::WHITE_BALANCE_MODE,
-                  (uint32_t)CameraParameters::id_white_balance_mode::ID_WHITE_BALANCE_AUTO);
+                  (uint32_t)CameraParameters::ID_WHITE_BALANCE_AUTO);
     saveParameter(CameraParameters::GAMMA, (uint32_t)220);
     saveParameter(CameraParameters::GAIN, (uint32_t)32);
     saveParameter(CameraParameters::POWER_LINE_FREQ_MODE, (uint32_t)0);
@@ -108,15 +107,12 @@ void CameraComponent_V4L2::initDefaultValues()
     saveParameter(CameraParameters::EXPOSURE_MODE, (uint32_t)3);
     saveParameter(CameraParameters::EXPOSURE_ABSOLUTE, (uint32_t)1);
     saveParameter(CameraParameters::VIDEO_SIZE,
-                  (uint32_t)CameraParameters::id_video_size::ID_VIDEO_SIZE_640x480x30);
+                  (uint32_t)CameraParameters::ID_VIDEO_SIZE_640x480x30);
 
     // dummy values
-    saveParameter(CameraParameters::IMAGE_SIZE,
-                  CameraParameters::id_image_size::ID_IMAGE_SIZE_3264x2448);
-    saveParameter(CameraParameters::IMAGE_FORMAT,
-                  CameraParameters::id_image_format::ID_IMAGE_FORMAT_JPEG);
-    saveParameter(CameraParameters::PIXEL_FORMAT,
-                  CameraParameters::id_pixel_format::ID_PIXEL_FORMAT_YUV420P);
+    saveParameter(CameraParameters::IMAGE_SIZE, CameraParameters::ID_IMAGE_SIZE_3264x2448);
+    saveParameter(CameraParameters::IMAGE_FORMAT, CameraParameters::ID_IMAGE_FORMAT_JPEG);
+    saveParameter(CameraParameters::PIXEL_FORMAT, CameraParameters::ID_PIXEL_FORMAT_YUV420P);
 }
 
 int CameraComponent_V4L2::getParam(const char *param_id, char *param_value)
@@ -324,6 +320,7 @@ int CameraComponent_V4L2::saveParameter(const char *param_id, float param_value)
 
 int CameraComponent_V4L2::saveParameter(const char *param_id, uint32_t param_value)
 {
+    log_debug("saveParameter Id:%s Value:%d", param_id, param_value);
     char str[128];
     mavlink_param_union_t u;
     u.param_uint32 = param_value;

--- a/src/CameraComponent_V4L2.cpp
+++ b/src/CameraComponent_V4L2.cpp
@@ -26,16 +26,15 @@
 #include "util.h"
 #include "v4l2_interface.h"
 
-CameraComponent_V4L2::CameraComponent_V4L2()
-    : CameraComponent()
-{
-}
-
 CameraComponent_V4L2::CameraComponent_V4L2(std::string devicepath)
     : CameraComponent()
     , dev_path(devicepath)
 {
     log_debug("%s path:%s", __func__, devicepath.c_str());
+    initCameraInfo();
+    initStorageInfo();
+    initSupportedValues();
+    initDefaultValues();
 }
 
 CameraComponent_V4L2::CameraComponent_V4L2(std::string devicepath, std::string uri)
@@ -46,13 +45,15 @@ CameraComponent_V4L2::CameraComponent_V4L2(std::string devicepath, std::string u
     log_debug("%s path:%s uri:%s", __func__, devicepath.c_str(), uri.c_str());
     // TODO:: get the supported parameters from the camera device
     // Initialize the supported and default values
-    if (sizeof(camInfo.cam_definition_uri) < uri.size() + 1) {
+    if (sizeof(camInfo.cam_definition_uri) > uri.size()) {
+        strcpy((char *)camInfo.cam_definition_uri, uri.c_str());
+    } else {
         log_error("URI length bigger than permitted");
         // TODO::Continue with no parameter support
-    } else
-        strcpy((char *)camInfo.cam_definition_uri, uri.c_str());
+    }
 
     initCameraInfo();
+    initStorageInfo();
     initSupportedValues();
     initDefaultValues();
 }
@@ -103,6 +104,7 @@ void CameraComponent_V4L2::initSupportedValues()
 void CameraComponent_V4L2::initDefaultValues()
 {
     // TODO :: Get the details of the default values from the camera device instead
+    mCamMode = CameraParameters::ID_CAMERA_MODE_VIDEO;
     camParam.setParameter(CameraParameters::CAMERA_MODE,
                           (uint32_t)CameraParameters::ID_CAMERA_MODE_VIDEO);
     camParam.setParameter(CameraParameters::BRIGHTNESS, (uint32_t)56);

--- a/src/CameraComponent_V4L2.cpp
+++ b/src/CameraComponent_V4L2.cpp
@@ -100,29 +100,31 @@ void CameraComponent_V4L2::initSupportedValues()
 
 void CameraComponent_V4L2::initDefaultValues()
 {
-    // TODO :: Get the details of the default values from the camera device and then save it in DB
-    saveParameter(CameraParameters::CAMERA_MODE, (uint32_t)CameraParameters::ID_CAMERA_MODE_VIDEO);
-    saveParameter(CameraParameters::BRIGHTNESS, (uint32_t)56);
-    saveParameter(CameraParameters::CONTRAST, (uint32_t)32);
-    saveParameter(CameraParameters::SATURATION, (uint32_t)128);
-    saveParameter(CameraParameters::HUE, (int32_t)0);
-    saveParameter(CameraParameters::WHITE_BALANCE_MODE,
-                  (uint32_t)CameraParameters::ID_WHITE_BALANCE_AUTO);
-    saveParameter(CameraParameters::GAMMA, (uint32_t)220);
-    saveParameter(CameraParameters::GAIN, (uint32_t)32);
-    saveParameter(CameraParameters::POWER_LINE_FREQ_MODE, (uint32_t)0);
-    saveParameter(CameraParameters::WHITE_BALANCE_TEMPERATURE, (uint32_t)6500);
-    saveParameter(CameraParameters::SHARPNESS, (uint32_t)0);
-    saveParameter(CameraParameters::BACKLIGHT_COMPENSATION, (uint32_t)1);
-    saveParameter(CameraParameters::EXPOSURE_MODE, (uint32_t)3);
-    saveParameter(CameraParameters::EXPOSURE_ABSOLUTE, (uint32_t)1);
-    saveParameter(CameraParameters::VIDEO_SIZE,
-                  (uint32_t)CameraParameters::ID_VIDEO_SIZE_640x480x30);
+    // TODO :: Get the details of the default values from the camera device instead
+    camParam.setParameter(CameraParameters::CAMERA_MODE,
+                          (uint32_t)CameraParameters::ID_CAMERA_MODE_VIDEO);
+    camParam.setParameter(CameraParameters::BRIGHTNESS, (uint32_t)56);
+    camParam.setParameter(CameraParameters::CONTRAST, (uint32_t)32);
+    camParam.setParameter(CameraParameters::SATURATION, (uint32_t)128);
+    camParam.setParameter(CameraParameters::HUE, (int32_t)0);
+    camParam.setParameter(CameraParameters::WHITE_BALANCE_MODE,
+                          (uint32_t)CameraParameters::ID_WHITE_BALANCE_AUTO);
+    camParam.setParameter(CameraParameters::GAMMA, (uint32_t)220);
+    camParam.setParameter(CameraParameters::GAIN, (uint32_t)32);
+    camParam.setParameter(CameraParameters::POWER_LINE_FREQ_MODE, (uint32_t)0);
+    camParam.setParameter(CameraParameters::WHITE_BALANCE_TEMPERATURE, (uint32_t)6500);
+    camParam.setParameter(CameraParameters::SHARPNESS, (uint32_t)0);
+    camParam.setParameter(CameraParameters::BACKLIGHT_COMPENSATION, (uint32_t)1);
+    camParam.setParameter(CameraParameters::EXPOSURE_MODE, (uint32_t)3);
+    camParam.setParameter(CameraParameters::EXPOSURE_ABSOLUTE, (uint32_t)1);
+    camParam.setParameter(CameraParameters::VIDEO_SIZE,
+                          (uint32_t)CameraParameters::ID_VIDEO_SIZE_640x480x30);
 
     // dummy values
-    saveParameter(CameraParameters::IMAGE_SIZE, CameraParameters::ID_IMAGE_SIZE_3264x2448);
-    saveParameter(CameraParameters::IMAGE_FORMAT, CameraParameters::ID_IMAGE_FORMAT_JPEG);
-    saveParameter(CameraParameters::PIXEL_FORMAT, CameraParameters::ID_PIXEL_FORMAT_YUV420P);
+    camParam.setParameter(CameraParameters::IMAGE_SIZE, CameraParameters::ID_IMAGE_SIZE_3264x2448);
+    camParam.setParameter(CameraParameters::IMAGE_FORMAT, CameraParameters::ID_IMAGE_FORMAT_JPEG);
+    camParam.setParameter(CameraParameters::PIXEL_FORMAT,
+                          CameraParameters::ID_PIXEL_FORMAT_YUV420P);
 }
 
 int CameraComponent_V4L2::getParam(const char *param_id, char *param_value, size_t value_size)
@@ -194,7 +196,7 @@ int CameraComponent_V4L2::setParam(std::string param_id, int32_t param_value)
             log_error("Error in setting control : %s Error:%d", param_id.c_str(), errno);
         v4l2_close(fd);
         if (!ret)
-            saveParameter(param_id, param_value);
+            camParam.setParameter(param_id, param_value);
     }
     return ret;
 }
@@ -280,7 +282,7 @@ int CameraComponent_V4L2::setParam(std::string param_id, uint32_t param_value)
             log_error("Error in setting control : %s Error:%d", param_id.c_str(), errno);
         v4l2_close(fd);
         if (!ret)
-            saveParameter(param_id, param_value);
+            camParam.setParameter(param_id, param_value);
     }
     return ret;
 }
@@ -330,44 +332,4 @@ int CameraComponent_V4L2::setVideoSize(uint32_t param_value)
 int CameraComponent_V4L2::setVideoFrameFormat(uint32_t param_value)
 {
     return 0;
-}
-
-bool CameraComponent_V4L2::saveParameter(std::string param_id, float param_value)
-{
-    char str[128];
-    mavlink_param_union_t u;
-    u.param_float = param_value;
-    memcpy(&str[0], &u.param_float, sizeof(float));
-    std::string str2(str, sizeof(str));
-    return camParam.setParameter(param_id, str2);
-}
-
-bool CameraComponent_V4L2::saveParameter(std::string param_id, uint32_t param_value)
-{
-    char str[128];
-    mavlink_param_union_t u;
-    u.param_uint32 = param_value;
-    memcpy(&str[0], &u.param_uint32, sizeof(uint32_t));
-    std::string str2(str, sizeof(str));
-    return camParam.setParameter(param_id, str2);
-}
-
-bool CameraComponent_V4L2::saveParameter(std::string param_id, int32_t param_value)
-{
-    char str[128];
-    mavlink_param_union_t u;
-    u.param_int32 = param_value;
-    memcpy(&str[0], &u.param_int32, sizeof(int32_t));
-    std::string str2(str, sizeof(str));
-    return camParam.setParameter(param_id, str2);
-}
-
-bool CameraComponent_V4L2::saveParameter(std::string param_id, uint8_t param_value)
-{
-    char str[128];
-    mavlink_param_union_t u;
-    u.param_uint8 = param_value;
-    memcpy(&str[0], &u.param_uint8, sizeof(uint8_t));
-    std::string str2(str, sizeof(str));
-    return camParam.setParameter(param_id, str2);
 }

--- a/src/CameraComponent_V4L2.cpp
+++ b/src/CameraComponent_V4L2.cpp
@@ -1,0 +1,467 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <assert.h>
+#include <fcntl.h>
+#include <linux/videodev2.h>
+#include <sstream>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "mavlink_server.h"
+
+#include "CameraComponent_V4L2.h"
+#include "log.h"
+
+CameraComponent_V4L2::CameraComponent_V4L2()
+    : CameraComponent()
+{
+}
+
+CameraComponent_V4L2::CameraComponent_V4L2(std::string devicepath)
+    : CameraComponent()
+{
+    log_debug("%s path:%s", __func__, devicepath.c_str());
+}
+
+CameraComponent_V4L2::CameraComponent_V4L2(std::string devicepath, std::string uri)
+    : CameraComponent()
+{
+
+    log_debug("%s path:%s uri:%s", __func__, devicepath.c_str(), uri.c_str());
+    // TODO:: get the supported paramters from the camera device
+    // Initialize the supported and default values
+    dev_path = devicepath;
+    strcpy((char *)camInfo.cam_definition_uri, uri.c_str());
+    initCameraInfo();
+    initSupportedValues();
+    initDefaultValues();
+}
+
+CameraComponent_V4L2::~CameraComponent_V4L2()
+{
+}
+
+void CameraComponent_V4L2::initCameraInfo()
+{
+    // TODO :: Get the details from the camera device
+    // Or read it from conf file
+    int fd = v4l2_open_device(dev_path.c_str());
+    v4l2_device_info(fd);
+    v4l2_close_device(fd);
+
+    strcpy((char *)camInfo.vendorName, "Intel");
+    strcpy((char *)camInfo.modelName, "RealSense R200");
+    camInfo.firmware_version = 1;
+    camInfo.focal_length = 0;
+    camInfo.sensor_size_h = 0;
+    camInfo.sensor_size_v = 0;
+    camInfo.resolution_h = 0;
+    camInfo.resolution_v = 0;
+    camInfo.lens_id = 0;
+    camInfo.flags = ~0u;
+    camInfo.cam_definition_version = 1;
+}
+
+void CameraComponent_V4L2::initStorageInfo()
+{
+    // TODO:: Fill storage details with values
+}
+
+void CameraComponent_V4L2::initSupportedValues()
+{
+    // TODO :: Get the details of the supported list from the camera device or from xml/conf file
+}
+
+void CameraComponent_V4L2::initDefaultValues()
+{
+    // TODO :: Get the details of the default values from the camera device and then save it in DB
+    saveParameter(CameraParameters::CAMERA_MODE,
+                  (uint32_t)CameraParameters::id_camera_mode::ID_CAMERA_MODE_VIDEO);
+    saveParameter(CameraParameters::BRIGHTNESS, (uint32_t)56);
+    saveParameter(CameraParameters::CONTRAST, (uint32_t)32);
+    saveParameter(CameraParameters::SATURATION, (uint32_t)128);
+    saveParameter(CameraParameters::HUE, (int32_t)0);
+    saveParameter(CameraParameters::WHITE_BALANCE_MODE,
+                  (uint32_t)CameraParameters::id_white_balance_mode::ID_WHITE_BALANCE_AUTO);
+    saveParameter(CameraParameters::GAMMA, (uint32_t)220);
+    saveParameter(CameraParameters::GAIN, (uint32_t)32);
+    saveParameter(CameraParameters::POWER_LINE_FREQ_MODE, (uint32_t)0);
+    saveParameter(CameraParameters::WHITE_BALANCE_TEMPERATURE, (uint32_t)6500);
+    saveParameter(CameraParameters::SHARPNESS, (uint32_t)0);
+    saveParameter(CameraParameters::BACKLIGHT_COMPENSATION, (uint32_t)1);
+    saveParameter(CameraParameters::EXPOSURE_MODE, (uint32_t)3);
+    saveParameter(CameraParameters::EXPOSURE_ABSOLUTE, (uint32_t)1);
+    saveParameter(CameraParameters::VIDEO_SIZE,
+                  (uint32_t)CameraParameters::id_video_size::ID_VIDEO_SIZE_640x480x30);
+
+    // dummy values
+    saveParameter(CameraParameters::IMAGE_SIZE,
+                  CameraParameters::id_image_size::ID_IMAGE_SIZE_3264x2448);
+    saveParameter(CameraParameters::IMAGE_FORMAT,
+                  CameraParameters::id_image_format::ID_IMAGE_FORMAT_JPEG);
+    saveParameter(CameraParameters::PIXEL_FORMAT,
+                  CameraParameters::id_pixel_format::ID_PIXEL_FORMAT_YUV420P);
+}
+
+int CameraComponent_V4L2::getParam(const char *param_id, char *param_value)
+{
+    // TODO :: Do appropriate checks
+    // query the value set in the map and fill the output, return appropriate value
+    std::string value = camParam.getParameter(param_id);
+    strcpy(param_value, value.c_str());
+    return 1;
+}
+
+int CameraComponent_V4L2::setParam(const char *param_id, const char *param_value, int param_type)
+{
+    int ret = 1;
+    mavlink_param_union_t u;
+    memcpy(&u.param_float, param_value, sizeof(float));
+    switch (param_type) {
+    case CameraParameters::PARAM_TYPE_REAL32:
+        setParam(param_id, u.param_float);
+        break;
+    case CameraParameters::PARAM_TYPE_INT32:
+        setParam(param_id, u.param_int32);
+        break;
+    case CameraParameters::PARAM_TYPE_UINT32:
+        setParam(param_id, u.param_uint32);
+        break;
+    case CameraParameters::PARAM_TYPE_UINT8:
+        setParam(param_id, u.param_uint8);
+        break;
+    default:
+        break;
+    }
+
+    return ret;
+}
+
+int CameraComponent_V4L2::setParam(const char *param_id, float param_value)
+{
+    log_debug("%s: Param Id:%s Value:%lf", __func__, param_id, param_value);
+    return 0;
+}
+
+int CameraComponent_V4L2::setParam(const char *param_id, int32_t param_value)
+{
+    log_debug("%s: Param Id:%s Value:%d", __func__, param_id, param_value);
+    int ret = 0;
+    int ctrl_id = -1;
+    int paramID = camParam.getParameterID(param_id);
+    switch (paramID) {
+    case CameraParameters::PARAM_ID_HUE:
+        ctrl_id = V4L2_CID_HUE;
+        break;
+    default:
+        break;
+    }
+
+    if (ctrl_id != -1) {
+        int fd = v4l2_open_device(dev_path.c_str());
+        ret = v4l2_set_control(fd, ctrl_id, param_value);
+        if (ret)
+            log_error("Error in setting control : %s Error:%d", param_id, errno);
+        v4l2_close_device(fd);
+        if (!ret)
+            saveParameter(param_id, param_value);
+    }
+    return ret;
+}
+
+int CameraComponent_V4L2::setParam(const char *param_id, uint32_t param_value)
+{
+    // TODO :: Do appropriate checks
+    // Check if camera is open for any usecase?
+    // Check if param is available
+    // Check if param is already set to same value
+    // Check if value is supported
+    log_debug("%s: Param Id:%s Value:%d", __func__, param_id, param_value);
+    int ret = 0;
+    int ctrl_id = -1;
+    int paramID = camParam.getParameterID(param_id);
+    switch (paramID) {
+    case CameraParameters::PARAM_ID_CAMERA_MODE:
+        ret = setCameraMode(param_value);
+        break;
+    case CameraParameters::PARAM_ID_BRIGHTNESS:
+        ctrl_id = V4L2_CID_BRIGHTNESS;
+        break;
+    case CameraParameters::PARAM_ID_CONTRAST:
+        ctrl_id = V4L2_CID_CONTRAST;
+        break;
+    case CameraParameters::PARAM_ID_SATURATION:
+        ctrl_id = V4L2_CID_SATURATION;
+        break;
+    case CameraParameters::PARAM_ID_WHITE_BALANCE_MODE:
+        ctrl_id = V4L2_CID_AUTO_WHITE_BALANCE;
+        break;
+    case CameraParameters::PARAM_ID_GAMMA:
+        ctrl_id = V4L2_CID_GAMMA;
+        break;
+    case CameraParameters::PARAM_ID_GAIN:
+        ctrl_id = V4L2_CID_GAIN;
+        break;
+    case CameraParameters::PARAM_ID_POWER_LINE_FREQ_MODE:
+        ctrl_id = V4L2_CID_POWER_LINE_FREQUENCY;
+        break;
+    case CameraParameters::PARAM_ID_WHITE_BALANCE_TEMPERATURE:
+        ctrl_id = V4L2_CID_WHITE_BALANCE_TEMPERATURE;
+        break;
+    case CameraParameters::PARAM_ID_SHARPNESS:
+        ctrl_id = V4L2_CID_SHARPNESS;
+        break;
+    case CameraParameters::PARAM_ID_BACKLIGHT_COMPENSATION:
+        ctrl_id = V4L2_CID_BACKLIGHT_COMPENSATION;
+        break;
+    case CameraParameters::PARAM_ID_EXPOSURE_MODE:
+        ctrl_id = V4L2_CID_EXPOSURE_AUTO;
+        break;
+    case CameraParameters::PARAM_ID_EXPOSURE_ABSOLUTE:
+        ctrl_id = V4L2_CID_EXPOSURE_ABSOLUTE;
+        break;
+    case CameraParameters::PARAM_ID_IMAGE_SIZE:
+        ret = setImazeSize(param_value);
+        break;
+    case CameraParameters::PARAM_ID_IMAGE_FORMAT:
+        ret = setImageFormat(param_value);
+        break;
+    case CameraParameters::PARAM_ID_PIXEL_FORMAT:
+        ret = setPixelFormat(param_value);
+        break;
+    case CameraParameters::PARAM_ID_SCENE_MODE:
+        ret = setSceneMode(param_value);
+        break;
+    case CameraParameters::PARAM_ID_VIDEO_SIZE:
+        ret = setVideoSize(param_value);
+        break;
+    case CameraParameters::PARAM_ID_VIDEO_FRAME_FORMAT:
+        ret = setVideoFrameFormat(param_value);
+        break;
+    default:
+        ret = -1;
+        break;
+    }
+
+    if (ctrl_id != -1) {
+        int fd = v4l2_open_device(dev_path.c_str());
+        ret = v4l2_set_control(fd, ctrl_id, param_value);
+        if (ret)
+            log_error("Error in setting control : %s Error:%d", param_id, errno);
+        v4l2_close_device(fd);
+        if (!ret)
+            saveParameter(param_id, param_value);
+    }
+    return ret;
+}
+
+int CameraComponent_V4L2::setParam(const char *param_id, uint8_t param_value)
+{
+    log_debug("%s: Param Id:%s Value:%d", __func__, param_id, param_value);
+    return 0;
+}
+
+int CameraComponent_V4L2::setCameraMode(uint32_t param_value)
+{
+    return 0;
+}
+
+int CameraComponent_V4L2::setImazeSize(uint32_t param_value)
+{
+    return 0;
+}
+
+int CameraComponent_V4L2::setImageFormat(uint32_t param_value)
+{
+    return 0;
+}
+
+int CameraComponent_V4L2::setPixelFormat(uint32_t param_value)
+{
+    return 0;
+}
+
+int CameraComponent_V4L2::setSceneMode(uint32_t param_value)
+{
+    return 0;
+}
+
+int CameraComponent_V4L2::setVideoSize(uint32_t param_value)
+{
+    return 0;
+}
+
+int CameraComponent_V4L2::setVideoFrameFormat(uint32_t param_value)
+{
+    return 0;
+}
+
+int CameraComponent_V4L2::saveParameter(const char *param_id, float param_value)
+{
+    char str[128];
+    mavlink_param_union_t u;
+    u.param_float = param_value;
+    memcpy(&str[0], &u.param_float, sizeof(float));
+    camParam.setParameter(param_id, str);
+    return 0;
+}
+
+int CameraComponent_V4L2::saveParameter(const char *param_id, uint32_t param_value)
+{
+    char str[128];
+    mavlink_param_union_t u;
+    u.param_uint32 = param_value;
+    memcpy(&str[0], &u.param_float, sizeof(float));
+    camParam.setParameter(param_id, str);
+    return 0;
+}
+
+int CameraComponent_V4L2::saveParameter(const char *param_id, int32_t param_value)
+{
+    char str[128];
+    mavlink_param_union_t u;
+    u.param_int32 = param_value;
+    memcpy(&str[0], &u.param_float, sizeof(float));
+    camParam.setParameter(param_id, str);
+    return 0;
+}
+
+int CameraComponent_V4L2::saveParameter(const char *param_id, uint8_t param_value)
+{
+    char str[128];
+    mavlink_param_union_t u;
+    u.param_uint8 = param_value;
+    memcpy(&str[0], &u.param_float, sizeof(float));
+    camParam.setParameter(param_id, str);
+    return 0;
+}
+
+/*
+*
+* V4L2 Interfaces
+*
+*/
+
+int CameraComponent_V4L2::xioctl(int fd, int request, void *arg)
+{
+    int r;
+
+    do
+        r = ioctl(fd, request, arg);
+    while (-1 == r && EINTR == errno);
+
+    return r;
+}
+
+int CameraComponent_V4L2::v4l2_open_device(const char *devicepath)
+{
+    int fd = -1;
+    fd = open(devicepath, O_RDWR, 0);
+    if (fd < 0) {
+        log_error("Cannot open device '%s': %d: ", devicepath, errno);
+    }
+
+    return fd;
+}
+
+int CameraComponent_V4L2::v4l2_close_device(int fd)
+{
+    if (fd < 1)
+        return -1;
+
+    close(fd);
+    return 0;
+}
+
+int CameraComponent_V4L2::v4l2_get_control(int fd, int ctrl_id)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    struct v4l2_control ctrl = {0};
+    ctrl.id = ctrl_id;
+    ret = xioctl(fd, VIDIOC_G_CTRL, &ctrl);
+    if (ret == 0)
+        return ctrl.value;
+    else
+        return ret;
+}
+
+int CameraComponent_V4L2::v4l2_set_control(int fd, int ctrl_id, int value)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    struct v4l2_control c = {0};
+    c.id = ctrl_id;
+    c.value = value;
+    ret = xioctl(fd, VIDIOC_S_CTRL, &c);
+
+    return ret;
+}
+
+int CameraComponent_V4L2::v4l2_query_control(int fd)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    const unsigned next_fl = V4L2_CTRL_FLAG_NEXT_CTRL | V4L2_CTRL_FLAG_NEXT_COMPOUND;
+    struct v4l2_control ctrl = {0};
+    struct v4l2_queryctrl qctrl = {0};
+    qctrl.id = next_fl;
+    while (xioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0) {
+        if ((qctrl.flags & V4L2_CTRL_TYPE_BOOLEAN) || (qctrl.type & V4L2_CTRL_TYPE_INTEGER)) {
+            log_debug("Ctrl: %s Min:%d Max:%d Step:%d dflt:%d", qctrl.name, qctrl.minimum,
+                      qctrl.maximum, qctrl.step, qctrl.default_value);
+            ctrl.id = qctrl.id;
+            if (xioctl(fd, VIDIOC_G_CTRL, &ctrl) == 0) {
+                log_debug("Ctrl: %s Id:%x Value:%d\n", qctrl.name, ctrl.id, ctrl.value);
+            }
+        }
+        qctrl.id |= next_fl;
+    }
+    return 0;
+}
+
+int CameraComponent_V4L2::v4l2_device_info(int fd)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    struct v4l2_capability vcap;
+    ret = xioctl(fd, VIDIOC_QUERYCAP, &vcap);
+    if (ret)
+        return ret;
+
+    log_debug("\tDriver name   : %s", vcap.driver);
+    log_debug("\tCard type     : %s", vcap.card);
+    log_debug("\tBus info      : %s", vcap.bus_info);
+    log_debug("\tDriver version: %d.%d.%d", vcap.version >> 16, (vcap.version >> 8) & 0xff,
+              vcap.version & 0xff);
+    log_debug("\tCapabilities  : 0x%08X", vcap.capabilities);
+    if (vcap.capabilities & V4L2_CAP_DEVICE_CAPS) {
+        log_debug("\tDevice Caps   : 0x%08X", vcap.device_caps);
+    }
+
+    return 0;
+}

--- a/src/CameraComponent_V4L2.cpp
+++ b/src/CameraComponent_V4L2.cpp
@@ -81,6 +81,14 @@ void CameraComponent_V4L2::initCameraInfo()
 void CameraComponent_V4L2::initStorageInfo()
 {
     // TODO:: Fill storage details with values
+    storeInfo.storage_id = 1;
+    storeInfo.storage_count = 1;
+    storeInfo.status = 2; /*formatted*/
+    storeInfo.total_capacity = 50.0;
+    storeInfo.used_capacity = 0.0;
+    storeInfo.available_capacity = 50.0;
+    storeInfo.read_speed = 128;
+    storeInfo.write_speed = 128;
 }
 
 void CameraComponent_V4L2::initSupportedValues()

--- a/src/CameraComponent_V4L2.h
+++ b/src/CameraComponent_V4L2.h
@@ -25,7 +25,6 @@
 
 class CameraComponent_V4L2 final : public CameraComponent {
 public:
-    CameraComponent_V4L2();
     CameraComponent_V4L2(std::string dev_path);
     CameraComponent_V4L2(std::string dev_path, std::string uri);
     ~CameraComponent_V4L2();
@@ -44,7 +43,6 @@ public:
 private:
     std::string dev_path;
     int mCamMode;
-    int cam_fd;
     void initCameraInfo();
     void initStorageInfo();
     void initSupportedValues();

--- a/src/CameraComponent_V4L2.h
+++ b/src/CameraComponent_V4L2.h
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+#include "CameraComponent.h"
+#include "log.h"
+
+class CameraComponent_V4L2 final : public CameraComponent {
+public:
+    CameraComponent_V4L2();
+    CameraComponent_V4L2(std::string dev_path);
+    CameraComponent_V4L2(std::string dev_path, std::string uri);
+    ~CameraComponent_V4L2();
+    int getParam(const char *param_id, char *param_value);
+    int setParam(const char *param_id, const char *param_value, int param_type);
+    int setParam(const char *param_id, float param_value);
+    int setParam(const char *param_id, int32_t param_value);
+    int setParam(const char *param_id, uint32_t param_value);
+    int setParam(const char *param_id, uint8_t param_value);
+
+private:
+    std::string dev_path;
+    int cam_fd;
+    void initCameraInfo();
+    void initStorageInfo();
+    void initSupportedValues();
+    void initDefaultValues();
+    int setCameraMode(uint32_t param_value);
+    int setImazeSize(uint32_t wb_value);
+    int setImageFormat(uint32_t wb_value);
+    int setPixelFormat(uint32_t wb_value);
+    int setSceneMode(uint32_t wb_value);
+    int setVideoSize(uint32_t wb_value);
+    int setVideoFrameFormat(uint32_t wb_value);
+
+    int saveParameter(const char *param_id, float param_value);
+    int saveParameter(const char *param_id, uint32_t param_value);
+    int saveParameter(const char *param_id, int32_t param_value);
+    int saveParameter(const char *param_id, uint8_t param_value);
+
+    int xioctl(int fd, int request, void *arg);
+    int v4l2_open_device(const char *dev_path);
+    int v4l2_close_device(int fd);
+    int v4l2_device_info(int fd);
+    int v4l2_get_control(int fd, int ctrl_id);
+    int v4l2_set_control(int fd, int ctrl_id, int value);
+    int v4l2_query_control(int fd);
+};

--- a/src/CameraComponent_V4L2.h
+++ b/src/CameraComponent_V4L2.h
@@ -57,12 +57,4 @@ private:
     bool saveParameter(std::string param_id, uint32_t param_value);
     bool saveParameter(std::string param_id, int32_t param_value);
     bool saveParameter(std::string param_id, uint8_t param_value);
-
-    int xioctl(int fd, int request, void *arg);
-    int v4l2_open_device(const char *dev_path);
-    int v4l2_close_device(int fd);
-    int v4l2_device_info(int fd);
-    int v4l2_get_control(int fd, int ctrl_id);
-    int v4l2_set_control(int fd, int ctrl_id, int value);
-    int v4l2_query_control(int fd);
 };

--- a/src/CameraComponent_V4L2.h
+++ b/src/CameraComponent_V4L2.h
@@ -54,9 +54,4 @@ private:
     int setSceneMode(uint32_t wb_value);
     int setVideoSize(uint32_t wb_value);
     int setVideoFrameFormat(uint32_t wb_value);
-
-    bool saveParameter(std::string param_id, float param_value);
-    bool saveParameter(std::string param_id, uint32_t param_value);
-    bool saveParameter(std::string param_id, int32_t param_value);
-    bool saveParameter(std::string param_id, uint8_t param_value);
 };

--- a/src/CameraComponent_V4L2.h
+++ b/src/CameraComponent_V4L2.h
@@ -29,10 +29,11 @@ public:
     CameraComponent_V4L2(std::string dev_path);
     CameraComponent_V4L2(std::string dev_path, std::string uri);
     ~CameraComponent_V4L2();
-    int getParam(const char *param_id /*Null Terminated*/, char *param_value /*o/p Byte Array*/,
+    int getParamType(const char *param_id, size_t id_size);
+    int getParam(const char *param_id, size_t id_size, char *param_value /*o/p Byte Array*/,
                  size_t value_size);
-    int setParam(const char *param_id /*Null Terminated*/,
-                 const char *param_value /*i/p Byte Array*/, size_t value_size, int param_type);
+    int setParam(const char *param_id, size_t id_size, const char *param_value /*i/p Byte Array*/,
+                 size_t value_size, int param_type);
     int setParam(std::string param_id, float param_value);
     int setParam(std::string param_id, int32_t param_value);
     int setParam(std::string param_id, uint32_t param_value);
@@ -54,4 +55,5 @@ private:
     int setSceneMode(uint32_t wb_value);
     int setVideoSize(uint32_t wb_value);
     int setVideoFrameFormat(uint32_t wb_value);
+    std::string toString(const char *buf, size_t buf_size);
 };

--- a/src/CameraComponent_V4L2.h
+++ b/src/CameraComponent_V4L2.h
@@ -29,12 +29,14 @@ public:
     CameraComponent_V4L2(std::string dev_path);
     CameraComponent_V4L2(std::string dev_path, std::string uri);
     ~CameraComponent_V4L2();
-    int getParam(const char *param_id, char *param_value);
-    int setParam(const char *param_id, const char *param_value, int param_type);
-    int setParam(const char *param_id, float param_value);
-    int setParam(const char *param_id, int32_t param_value);
-    int setParam(const char *param_id, uint32_t param_value);
-    int setParam(const char *param_id, uint8_t param_value);
+    int getParam(const char *param_id /*Null Terminated*/, char *param_value /*o/p Byte Array*/,
+                 size_t value_size);
+    int setParam(const char *param_id /*Null Terminated*/,
+                 const char *param_value /*i/p Byte Array*/, size_t value_size, int param_type);
+    int setParam(std::string param_id, float param_value);
+    int setParam(std::string param_id, int32_t param_value);
+    int setParam(std::string param_id, uint32_t param_value);
+    int setParam(std::string param_id, uint8_t param_value);
 
 private:
     std::string dev_path;
@@ -51,10 +53,10 @@ private:
     int setVideoSize(uint32_t wb_value);
     int setVideoFrameFormat(uint32_t wb_value);
 
-    int saveParameter(const char *param_id, float param_value);
-    int saveParameter(const char *param_id, uint32_t param_value);
-    int saveParameter(const char *param_id, int32_t param_value);
-    int saveParameter(const char *param_id, uint8_t param_value);
+    bool saveParameter(std::string param_id, float param_value);
+    bool saveParameter(std::string param_id, uint32_t param_value);
+    bool saveParameter(std::string param_id, int32_t param_value);
+    bool saveParameter(std::string param_id, uint8_t param_value);
 
     int xioctl(int fd, int request, void *arg);
     int v4l2_open_device(const char *dev_path);

--- a/src/CameraComponent_V4L2.h
+++ b/src/CameraComponent_V4L2.h
@@ -37,15 +37,17 @@ public:
     int setParam(std::string param_id, int32_t param_value);
     int setParam(std::string param_id, uint32_t param_value);
     int setParam(std::string param_id, uint8_t param_value);
+    int setCameraMode(uint32_t mode);
+    int getCameraMode();
 
 private:
     std::string dev_path;
+    int mCamMode;
     int cam_fd;
     void initCameraInfo();
     void initStorageInfo();
     void initSupportedValues();
     void initDefaultValues();
-    int setCameraMode(uint32_t param_value);
     int setImazeSize(uint32_t wb_value);
     int setImageFormat(uint32_t wb_value);
     int setPixelFormat(uint32_t wb_value);

--- a/src/CameraParameters.cpp
+++ b/src/CameraParameters.cpp
@@ -85,53 +85,49 @@ CameraParameters::~CameraParameters()
 
 bool CameraParameters::setParameterSupported(std::string key, std::string value)
 {
-    // TODO::Check if the key and value are valid
+    if (key.size() > CAM_PARAM_ID_LEN || value.size() > CAM_PARAM_VALUE_LEN)
+        return false;
+
     paramValuesSupported[key] = value;
     return true;
 }
 
 bool CameraParameters::setParameter(std::string key, std::string value)
 {
-    // TODO::Check if the key and value are valid
+    if (key.size() > CAM_PARAM_ID_LEN || value.size() > CAM_PARAM_VALUE_LEN)
+        return false;
+
     paramValue[key] = value;
     return true;
 }
 
 bool CameraParameters::setParameter(std::string param_id, float param_value)
 {
-    char str[CAM_PARAM_VALUE_LEN];
-    cam_param_union u;
+    cam_param_union_t u;
     u.param_float = param_value;
-    memcpy(&str[0], &u.param_float, sizeof(float));
-    std::string str2(str, sizeof(str));
-    return setParameter(param_id, str2);
+    std::string str(reinterpret_cast<char const *>(u.bytes), CAM_PARAM_VALUE_LEN);
+    return setParameter(param_id, str);
 }
 bool CameraParameters::setParameter(std::string param_id, uint32_t param_value)
 {
-    char str[CAM_PARAM_VALUE_LEN];
-    cam_param_union u;
+    cam_param_union_t u;
     u.param_uint32 = param_value;
-    memcpy(&str[0], &u.param_uint32, sizeof(uint32_t));
-    std::string str2(str, sizeof(str));
-    return setParameter(param_id, str2);
+    std::string str(reinterpret_cast<char const *>(u.bytes), CAM_PARAM_VALUE_LEN);
+    return setParameter(param_id, str);
 }
 bool CameraParameters::setParameter(std::string param_id, int32_t param_value)
 {
-    char str[CAM_PARAM_VALUE_LEN];
-    cam_param_union u;
+    cam_param_union_t u;
     u.param_int32 = param_value;
-    memcpy(&str[0], &u.param_int32, sizeof(int32_t));
-    std::string str2(str, sizeof(str));
-    return setParameter(param_id, str2);
+    std::string str(reinterpret_cast<char const *>(u.bytes), CAM_PARAM_VALUE_LEN);
+    return setParameter(param_id, str);
 }
 bool CameraParameters::setParameter(std::string param_id, uint8_t param_value)
 {
-    char str[CAM_PARAM_VALUE_LEN];
-    cam_param_union u;
+    cam_param_union_t u;
     u.param_uint8 = param_value;
-    memcpy(&str[0], &u.param_uint8, sizeof(uint8_t));
-    std::string str2(str, sizeof(str));
-    return setParameter(param_id, str2);
+    std::string str(reinterpret_cast<char const *>(u.bytes), CAM_PARAM_VALUE_LEN);
+    return setParameter(param_id, str);
 }
 
 std::string CameraParameters::getParameter(std::string key)

--- a/src/CameraParameters.cpp
+++ b/src/CameraParameters.cpp
@@ -97,6 +97,43 @@ bool CameraParameters::setParameter(std::string key, std::string value)
     return true;
 }
 
+bool CameraParameters::setParameter(std::string param_id, float param_value)
+{
+    char str[CAM_PARAM_VALUE_LEN];
+    cam_param_union u;
+    u.param_float = param_value;
+    memcpy(&str[0], &u.param_float, sizeof(float));
+    std::string str2(str, sizeof(str));
+    return setParameter(param_id, str2);
+}
+bool CameraParameters::setParameter(std::string param_id, uint32_t param_value)
+{
+    char str[CAM_PARAM_VALUE_LEN];
+    cam_param_union u;
+    u.param_uint32 = param_value;
+    memcpy(&str[0], &u.param_uint32, sizeof(uint32_t));
+    std::string str2(str, sizeof(str));
+    return setParameter(param_id, str2);
+}
+bool CameraParameters::setParameter(std::string param_id, int32_t param_value)
+{
+    char str[CAM_PARAM_VALUE_LEN];
+    cam_param_union u;
+    u.param_int32 = param_value;
+    memcpy(&str[0], &u.param_int32, sizeof(int32_t));
+    std::string str2(str, sizeof(str));
+    return setParameter(param_id, str2);
+}
+bool CameraParameters::setParameter(std::string param_id, uint8_t param_value)
+{
+    char str[CAM_PARAM_VALUE_LEN];
+    cam_param_union u;
+    u.param_uint8 = param_value;
+    memcpy(&str[0], &u.param_uint8, sizeof(uint8_t));
+    std::string str2(str, sizeof(str));
+    return setParameter(param_id, str2);
+}
+
 std::string CameraParameters::getParameter(std::string key)
 {
     if (paramValue.find(key) == paramValue.end())

--- a/src/CameraParameters.cpp
+++ b/src/CameraParameters.cpp
@@ -1,0 +1,180 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <assert.h>
+#include <cstring>
+#include <sstream>
+#include <string.h>
+
+#include "CameraParameters.h"
+#include "log.h"
+
+const char CameraParameters::CAMERA_MODE[] = "camera-mode";
+const char CameraParameters::BRIGHTNESS[] = "brightness";
+const char CameraParameters::CONTRAST[] = "contrast";
+const char CameraParameters::SATURATION[] = "saturation";
+const char CameraParameters::HUE[] = "hue";
+const char CameraParameters::WHITE_BALANCE_MODE[] = "wb-mode";
+const char CameraParameters::GAMMA[] = "gamma";
+const char CameraParameters::GAIN[] = "gain";
+const char CameraParameters::POWER_LINE_FREQ_MODE[] = "power-mode";
+const char CameraParameters::WHITE_BALANCE_TEMPERATURE[] = "wb-temp";
+const char CameraParameters::SHARPNESS[] = "sharpness";
+const char CameraParameters::BACKLIGHT_COMPENSATION[] = "backlight";
+const char CameraParameters::EXPOSURE_MODE[] = "exp-mode";
+const char CameraParameters::EXPOSURE_ABSOLUTE[] = "exp-absolute";
+const char CameraParameters::IMAGE_SIZE[] = "image-size";
+const char CameraParameters::IMAGE_FORMAT[] = "image-format";
+const char CameraParameters::PIXEL_FORMAT[] = "pixel-format";
+const char CameraParameters::SCENE_MODE[] = "scene-mode";
+const char CameraParameters::VIDEO_SIZE[] = "video-size";
+const char CameraParameters::VIDEO_FRAME_FORMAT[] = "video-format";
+const char CameraParameters::IMAGE_CAPTURE[] = "img-capture";
+const char CameraParameters::VIDEO_CAPTURE[] = "vid-capture";
+const char CameraParameters::VIDEO_SNAPSHOT[] = "vid-snapshot";
+const char CameraParameters::IMAGE_VIDEOSHOT[] = "img-videoshot";
+
+/* ++Need to check if required, as we have defined values as enums++ */
+const char CameraParameters::CAMERA_MODE_STILL[] = "still";
+const char CameraParameters::CAMERA_MODE_VIDEO[] = "video";
+const char CameraParameters::CAMERA_MODE_PREVIEW[] = "preview";
+
+const char CameraParameters::IMAGE_FORMAT_JPEG[] = "jpg";
+const char CameraParameters::IMAGE_FORMAT_PNG[] = "png";
+
+const char CameraParameters::PIXEL_FORMAT_YUV422SP[] = "yuv422sp";
+const char CameraParameters::PIXEL_FORMAT_YUV420SP[] = "yuv420sp";
+const char CameraParameters::PIXEL_FORMAT_YUV422I[] = "yuv422i";
+const char CameraParameters::PIXEL_FORMAT_YUV420P[] = "yuv420p";
+const char CameraParameters::PIXEL_FORMAT_RGB565[] = "rgb565";
+const char CameraParameters::PIXEL_FORMAT_RGBA8888[] = "rgba8888";
+
+// Values for white balance settings.
+const char CameraParameters::WHITE_BALANCE_AUTO[] = "auto";
+const char CameraParameters::WHITE_BALANCE_INCANDESCENT[] = "incandescent";
+const char CameraParameters::WHITE_BALANCE_FLUORESCENT[] = "fluorescent";
+const char CameraParameters::WHITE_BALANCE_WARM_FLUORESCENT[] = "warm-fluorescent";
+const char CameraParameters::WHITE_BALANCE_DAYLIGHT[] = "daylight";
+const char CameraParameters::WHITE_BALANCE_CLOUDY_DAYLIGHT[] = "cloudy-daylight";
+const char CameraParameters::WHITE_BALANCE_TWILIGHT[] = "twilight";
+const char CameraParameters::WHITE_BALANCE_SHADE[] = "shade";
+/* --Need to check if required-- */
+
+CameraParameters::CameraParameters()
+{
+    initParamIdType();
+}
+
+CameraParameters::~CameraParameters()
+{
+}
+
+int CameraParameters::setParameterSupported(std::string key, std::string value)
+{
+    set(paramValuesSupported, key, value);
+    return 1;
+}
+
+int CameraParameters::setParameter(std::string key, std::string value)
+{
+    set(paramValue, key, value);
+    return 1;
+}
+
+std::string CameraParameters::getParameter(std::string key)
+{
+    return get(paramValue, key);
+}
+
+int CameraParameters::getParameterID(std::string param)
+{
+    // TODO :: Create a map of paramString to paramID
+    int ret = -1;
+    std::map<std::string, std::pair<int, int>>::iterator it = paramIdType.find(param);
+    if (it != paramIdType.end()) {
+        ret = it->second.first;
+    } else
+        ret = -1;
+    return ret;
+}
+
+int CameraParameters::getParameterType(std::string param)
+{
+    // TODO :: Create a map of paramString to paramType
+    int ret = -1;
+    std::map<std::string, std::pair<int, int>>::iterator it = paramIdType.find(param);
+    if (it != paramIdType.end()) {
+        ret = it->second.second;
+    } else
+        ret = -1;
+    return ret;
+}
+
+void CameraParameters::initParamIdType()
+{
+    set(paramIdType, CAMERA_MODE, std::make_pair(PARAM_ID_CAMERA_MODE, PARAM_TYPE_UINT32));
+    set(paramIdType, BRIGHTNESS, std::make_pair(PARAM_ID_BRIGHTNESS, PARAM_TYPE_UINT32));
+    set(paramIdType, CONTRAST, std::make_pair(PARAM_ID_CONTRAST, PARAM_TYPE_UINT32));
+    set(paramIdType, SATURATION, std::make_pair(PARAM_ID_SATURATION, PARAM_TYPE_UINT32));
+    set(paramIdType, HUE, std::make_pair(PARAM_ID_HUE, PARAM_TYPE_INT32));
+    set(paramIdType, WHITE_BALANCE_MODE,
+        std::make_pair(PARAM_ID_WHITE_BALANCE_MODE, PARAM_TYPE_UINT32));
+    set(paramIdType, GAMMA, std::make_pair(PARAM_ID_GAMMA, PARAM_TYPE_UINT32));
+    set(paramIdType, GAIN, std::make_pair(PARAM_ID_GAIN, PARAM_TYPE_UINT32));
+    set(paramIdType, POWER_LINE_FREQ_MODE,
+        std::make_pair(PARAM_ID_POWER_LINE_FREQ_MODE, PARAM_TYPE_UINT32));
+    set(paramIdType, WHITE_BALANCE_TEMPERATURE,
+        std::make_pair(PARAM_ID_WHITE_BALANCE_TEMPERATURE, PARAM_TYPE_UINT32));
+    set(paramIdType, SHARPNESS, std::make_pair(PARAM_ID_SHARPNESS, PARAM_TYPE_UINT32));
+    set(paramIdType, BACKLIGHT_COMPENSATION,
+        std::make_pair(PARAM_ID_BACKLIGHT_COMPENSATION, PARAM_TYPE_UINT32));
+    set(paramIdType, EXPOSURE_MODE, std::make_pair(PARAM_ID_EXPOSURE_MODE, PARAM_TYPE_UINT32));
+    set(paramIdType, EXPOSURE_ABSOLUTE,
+        std::make_pair(PARAM_ID_EXPOSURE_ABSOLUTE, PARAM_TYPE_UINT32));
+    set(paramIdType, IMAGE_SIZE, std::make_pair(PARAM_ID_IMAGE_SIZE, PARAM_TYPE_UINT32));
+    set(paramIdType, IMAGE_FORMAT, std::make_pair(PARAM_ID_IMAGE_FORMAT, PARAM_TYPE_UINT32));
+    set(paramIdType, PIXEL_FORMAT, std::make_pair(PARAM_ID_PIXEL_FORMAT, PARAM_TYPE_UINT32));
+    set(paramIdType, WHITE_BALANCE_MODE,
+        std::make_pair(PARAM_ID_WHITE_BALANCE_MODE, PARAM_TYPE_UINT32));
+    set(paramIdType, SCENE_MODE, std::make_pair(PARAM_ID_SCENE_MODE, PARAM_TYPE_UINT32));
+    set(paramIdType, VIDEO_SIZE, std::make_pair(PARAM_ID_VIDEO_SIZE, PARAM_TYPE_UINT32));
+    set(paramIdType, VIDEO_FRAME_FORMAT,
+        std::make_pair(PARAM_ID_VIDEO_FRAME_FORMAT, PARAM_TYPE_UINT32));
+    set(paramIdType, VIDEO_SNAPSHOT,
+        std::make_pair(PARAM_ID_VIDEO_SNAPSHOT_SUPPORTED, PARAM_TYPE_UINT32));
+}
+
+void CameraParameters::set(std::map<std::string, std::string> &pMap, std::string key,
+                           std::string value)
+{
+    pMap.insert(std::make_pair(key, value));
+}
+
+void CameraParameters::set(std::map<std::string, std::pair<int, int>> &pMap, std::string key,
+                           std::pair<int, int> value)
+{
+    pMap.insert(std::make_pair(key, value));
+}
+
+std::string CameraParameters::get(std::map<std::string, std::string> &pMap, std::string key)
+{
+    std::map<std::string, std::string>::iterator it = pMap.find(key);
+    if (it != pMap.end())
+        return it->second;
+    else
+        return "";
+}

--- a/src/CameraParameters.cpp
+++ b/src/CameraParameters.cpp
@@ -100,7 +100,7 @@ bool CameraParameters::setParameter(std::string key, std::string value)
 std::string CameraParameters::getParameter(std::string key)
 {
     if (paramValue.find(key) == paramValue.end())
-        return "";
+        return std::string();
     else
         return paramValue[key];
 }

--- a/src/CameraParameters.cpp
+++ b/src/CameraParameters.cpp
@@ -83,26 +83,30 @@ CameraParameters::~CameraParameters()
 {
 }
 
-int CameraParameters::setParameterSupported(std::string key, std::string value)
+bool CameraParameters::setParameterSupported(std::string key, std::string value)
 {
-    set(paramValuesSupported, key, value);
-    return 1;
+    // TODO::Check if the key and value are valid
+    paramValuesSupported[key] = value;
+    return true;
 }
 
-int CameraParameters::setParameter(std::string key, std::string value)
+bool CameraParameters::setParameter(std::string key, std::string value)
 {
-    set(paramValue, key, value);
-    return 1;
+    // TODO::Check if the key and value are valid
+    paramValue[key] = value;
+    return true;
 }
 
 std::string CameraParameters::getParameter(std::string key)
 {
-    return get(paramValue, key);
+    if (paramValue.find(key) == paramValue.end())
+        return "";
+    else
+        return paramValue[key];
 }
 
 int CameraParameters::getParameterID(std::string param)
 {
-    // TODO :: Create a map of paramString to paramID
     int ret = -1;
     std::map<std::string, std::pair<int, int>>::iterator it = paramIdType.find(param);
     if (it != paramIdType.end()) {
@@ -114,7 +118,6 @@ int CameraParameters::getParameterID(std::string param)
 
 int CameraParameters::getParameterType(std::string param)
 {
-    // TODO :: Create a map of paramString to paramType
     int ret = -1;
     std::map<std::string, std::pair<int, int>>::iterator it = paramIdType.find(param);
     if (it != paramIdType.end()) {
@@ -126,55 +129,33 @@ int CameraParameters::getParameterType(std::string param)
 
 void CameraParameters::initParamIdType()
 {
-    set(paramIdType, CAMERA_MODE, std::make_pair(PARAM_ID_CAMERA_MODE, PARAM_TYPE_UINT32));
-    set(paramIdType, BRIGHTNESS, std::make_pair(PARAM_ID_BRIGHTNESS, PARAM_TYPE_UINT32));
-    set(paramIdType, CONTRAST, std::make_pair(PARAM_ID_CONTRAST, PARAM_TYPE_UINT32));
-    set(paramIdType, SATURATION, std::make_pair(PARAM_ID_SATURATION, PARAM_TYPE_UINT32));
-    set(paramIdType, HUE, std::make_pair(PARAM_ID_HUE, PARAM_TYPE_INT32));
-    set(paramIdType, WHITE_BALANCE_MODE,
-        std::make_pair(PARAM_ID_WHITE_BALANCE_MODE, PARAM_TYPE_UINT32));
-    set(paramIdType, GAMMA, std::make_pair(PARAM_ID_GAMMA, PARAM_TYPE_UINT32));
-    set(paramIdType, GAIN, std::make_pair(PARAM_ID_GAIN, PARAM_TYPE_UINT32));
-    set(paramIdType, POWER_LINE_FREQ_MODE,
-        std::make_pair(PARAM_ID_POWER_LINE_FREQ_MODE, PARAM_TYPE_UINT32));
-    set(paramIdType, WHITE_BALANCE_TEMPERATURE,
-        std::make_pair(PARAM_ID_WHITE_BALANCE_TEMPERATURE, PARAM_TYPE_UINT32));
-    set(paramIdType, SHARPNESS, std::make_pair(PARAM_ID_SHARPNESS, PARAM_TYPE_UINT32));
-    set(paramIdType, BACKLIGHT_COMPENSATION,
-        std::make_pair(PARAM_ID_BACKLIGHT_COMPENSATION, PARAM_TYPE_UINT32));
-    set(paramIdType, EXPOSURE_MODE, std::make_pair(PARAM_ID_EXPOSURE_MODE, PARAM_TYPE_UINT32));
-    set(paramIdType, EXPOSURE_ABSOLUTE,
-        std::make_pair(PARAM_ID_EXPOSURE_ABSOLUTE, PARAM_TYPE_UINT32));
-    set(paramIdType, IMAGE_SIZE, std::make_pair(PARAM_ID_IMAGE_SIZE, PARAM_TYPE_UINT32));
-    set(paramIdType, IMAGE_FORMAT, std::make_pair(PARAM_ID_IMAGE_FORMAT, PARAM_TYPE_UINT32));
-    set(paramIdType, PIXEL_FORMAT, std::make_pair(PARAM_ID_PIXEL_FORMAT, PARAM_TYPE_UINT32));
-    set(paramIdType, WHITE_BALANCE_MODE,
-        std::make_pair(PARAM_ID_WHITE_BALANCE_MODE, PARAM_TYPE_UINT32));
-    set(paramIdType, SCENE_MODE, std::make_pair(PARAM_ID_SCENE_MODE, PARAM_TYPE_UINT32));
-    set(paramIdType, VIDEO_SIZE, std::make_pair(PARAM_ID_VIDEO_SIZE, PARAM_TYPE_UINT32));
-    set(paramIdType, VIDEO_FRAME_FORMAT,
-        std::make_pair(PARAM_ID_VIDEO_FRAME_FORMAT, PARAM_TYPE_UINT32));
-    set(paramIdType, VIDEO_SNAPSHOT,
-        std::make_pair(PARAM_ID_VIDEO_SNAPSHOT_SUPPORTED, PARAM_TYPE_UINT32));
-}
-
-void CameraParameters::set(std::map<std::string, std::string> &pMap, std::string key,
-                           std::string value)
-{
-    pMap.insert(std::make_pair(key, value));
-}
-
-void CameraParameters::set(std::map<std::string, std::pair<int, int>> &pMap, std::string key,
-                           std::pair<int, int> value)
-{
-    pMap.insert(std::make_pair(key, value));
-}
-
-std::string CameraParameters::get(std::map<std::string, std::string> &pMap, std::string key)
-{
-    std::map<std::string, std::string>::iterator it = pMap.find(key);
-    if (it != pMap.end())
-        return it->second;
-    else
-        return "";
+    paramIdType[CAMERA_MODE] = std::make_pair(PARAM_ID_CAMERA_MODE, PARAM_TYPE_UINT32);
+    paramIdType[BRIGHTNESS] = std::make_pair(PARAM_ID_BRIGHTNESS, PARAM_TYPE_UINT32);
+    paramIdType[CONTRAST] = std::make_pair(PARAM_ID_CONTRAST, PARAM_TYPE_UINT32);
+    paramIdType[SATURATION] = std::make_pair(PARAM_ID_SATURATION, PARAM_TYPE_UINT32);
+    paramIdType[HUE] = std::make_pair(PARAM_ID_HUE, PARAM_TYPE_INT32);
+    paramIdType[WHITE_BALANCE_MODE]
+        = std::make_pair(PARAM_ID_WHITE_BALANCE_MODE, PARAM_TYPE_UINT32);
+    paramIdType[GAMMA] = std::make_pair(PARAM_ID_GAMMA, PARAM_TYPE_UINT32);
+    paramIdType[GAIN] = std::make_pair(PARAM_ID_GAIN, PARAM_TYPE_UINT32);
+    paramIdType[POWER_LINE_FREQ_MODE]
+        = std::make_pair(PARAM_ID_POWER_LINE_FREQ_MODE, PARAM_TYPE_UINT32);
+    paramIdType[WHITE_BALANCE_TEMPERATURE]
+        = std::make_pair(PARAM_ID_WHITE_BALANCE_TEMPERATURE, PARAM_TYPE_UINT32);
+    paramIdType[SHARPNESS] = std::make_pair(PARAM_ID_SHARPNESS, PARAM_TYPE_UINT32);
+    paramIdType[BACKLIGHT_COMPENSATION]
+        = std::make_pair(PARAM_ID_BACKLIGHT_COMPENSATION, PARAM_TYPE_UINT32);
+    paramIdType[EXPOSURE_MODE] = std::make_pair(PARAM_ID_EXPOSURE_MODE, PARAM_TYPE_UINT32);
+    paramIdType[EXPOSURE_ABSOLUTE] = std::make_pair(PARAM_ID_EXPOSURE_ABSOLUTE, PARAM_TYPE_UINT32);
+    paramIdType[IMAGE_SIZE] = std::make_pair(PARAM_ID_IMAGE_SIZE, PARAM_TYPE_UINT32);
+    paramIdType[IMAGE_FORMAT] = std::make_pair(PARAM_ID_IMAGE_FORMAT, PARAM_TYPE_UINT32);
+    paramIdType[PIXEL_FORMAT] = std::make_pair(PARAM_ID_PIXEL_FORMAT, PARAM_TYPE_UINT32);
+    paramIdType[SCENE_MODE] = std::make_pair(PARAM_ID_SCENE_MODE, PARAM_TYPE_UINT32);
+    paramIdType[VIDEO_SIZE] = std::make_pair(PARAM_ID_VIDEO_SIZE, PARAM_TYPE_UINT32);
+    paramIdType[VIDEO_FRAME_FORMAT]
+        = std::make_pair(PARAM_ID_VIDEO_FRAME_FORMAT, PARAM_TYPE_UINT32);
+    paramIdType[IMAGE_CAPTURE] = std::make_pair(PARAM_ID_IMAGE_CAPTURE, PARAM_TYPE_UINT32);
+    paramIdType[VIDEO_CAPTURE] = std::make_pair(PARAM_ID_VIDEO_CAPTURE, PARAM_TYPE_UINT32);
+    paramIdType[VIDEO_SNAPSHOT] = std::make_pair(PARAM_ID_VIDEO_SNAPSHOT, PARAM_TYPE_UINT32);
+    paramIdType[IMAGE_VIDEOSHOT] = std::make_pair(PARAM_ID_IMAGE_VIDEOSHOT, PARAM_TYPE_UINT32);
 }

--- a/src/CameraParameters.cpp
+++ b/src/CameraParameters.cpp
@@ -51,7 +51,7 @@ const char CameraParameters::IMAGE_VIDEOSHOT[] = "img-videoshot";
 /* ++Need to check if required, as we have defined values as enums++ */
 const char CameraParameters::CAMERA_MODE_STILL[] = "still";
 const char CameraParameters::CAMERA_MODE_VIDEO[] = "video";
-const char CameraParameters::CAMERA_MODE_PREVIEW[] = "preview";
+const char CameraParameters::CAMERA_MODE_IMAGE_SURVEY[] = "img-survey";
 
 const char CameraParameters::IMAGE_FORMAT_JPEG[] = "jpg";
 const char CameraParameters::IMAGE_FORMAT_PNG[] = "png";

--- a/src/CameraParameters.h
+++ b/src/CameraParameters.h
@@ -26,12 +26,12 @@ class CameraParameters {
 public:
     CameraParameters();
     virtual ~CameraParameters();
+    const std::map<std::string, std::string> &getParameterList() const { return paramValue; }
+    bool setParameterSupported(std::string key, std::string value);
+    bool setParameter(std::string param, std::string value);
+    std::string getParameter(std::string param);
     int getParameterType(std::string param);
     int getParameterID(std::string param);
-    int setParameterSupported(std::string key, std::string value);
-    int setParameter(std::string param, std::string value);
-    std::string getParameter(std::string param);
-    const std::map<std::string, std::string> &getParameterList() const { return paramValue; }
 
     enum param_type {
         PARAM_TYPE_UINT8 = 1,
@@ -96,93 +96,95 @@ public:
     static const char IMAGE_FORMAT_JPEG[];
     static const char IMAGE_FORMAT_PNG[];
 
-    enum param_id {
-        PARAM_ID_CAMERA_MODE = 1,
-        PARAM_ID_BRIGHTNESS,
-        PARAM_ID_CONTRAST,
-        PARAM_ID_SATURATION,
-        PARAM_ID_HUE,
-        PARAM_ID_WHITE_BALANCE_MODE,
-        PARAM_ID_GAMMA,
-        PARAM_ID_GAIN,
-        PARAM_ID_POWER_LINE_FREQ_MODE,
-        PARAM_ID_WHITE_BALANCE_TEMPERATURE,
-        PARAM_ID_SHARPNESS,
-        PARAM_ID_BACKLIGHT_COMPENSATION,
-        PARAM_ID_EXPOSURE_MODE,
-        PARAM_ID_EXPOSURE_ABSOLUTE,
-        PARAM_ID_IMAGE_SIZE,
-        PARAM_ID_IMAGE_FORMAT,
-        PARAM_ID_PIXEL_FORMAT,
-        PARAM_ID_SCENE_MODE,
-        PARAM_ID_VIDEO_SIZE,
-        PARAM_ID_VIDEO_FRAME_FORMAT,
-        PARAM_ID_VIDEO_SNAPSHOT_SUPPORTED
-    };
+    // ID for parameters
+    static const int PARAM_ID_CAMERA_MODE = 1;
+    static const int PARAM_ID_BRIGHTNESS = 2;
+    static const int PARAM_ID_CONTRAST = 3;
+    static const int PARAM_ID_SATURATION = 4;
+    static const int PARAM_ID_HUE = 5;
+    static const int PARAM_ID_WHITE_BALANCE_MODE = 6;
+    static const int PARAM_ID_GAMMA = 7;
+    static const int PARAM_ID_GAIN = 8;
+    static const int PARAM_ID_POWER_LINE_FREQ_MODE = 9;
+    static const int PARAM_ID_WHITE_BALANCE_TEMPERATURE = 10;
+    static const int PARAM_ID_SHARPNESS = 11;
+    static const int PARAM_ID_BACKLIGHT_COMPENSATION = 12;
+    static const int PARAM_ID_EXPOSURE_MODE = 13;
+    static const int PARAM_ID_EXPOSURE_ABSOLUTE = 14;
+    static const int PARAM_ID_IMAGE_SIZE = 15;
+    static const int PARAM_ID_IMAGE_FORMAT = 16;
+    static const int PARAM_ID_PIXEL_FORMAT = 17;
+    static const int PARAM_ID_SCENE_MODE = 18;
+    static const int PARAM_ID_VIDEO_SIZE = 19;
+    static const int PARAM_ID_VIDEO_FRAME_FORMAT = 20;
+    static const int PARAM_ID_IMAGE_CAPTURE = 21;
+    static const int PARAM_ID_VIDEO_CAPTURE = 22;
+    static const int PARAM_ID_VIDEO_SNAPSHOT = 23;
+    static const int PARAM_ID_IMAGE_VIDEOSHOT = 24;
 
-    enum id_image_size {
-        ID_IMAGE_SIZE_3264x2448 = 0,
-        ID_IMAGE_SIZE_3264x1836,
-        ID_IMAGE_SIZE_1920x1080
-    };
+    // ID for image sizes
+    static const int ID_IMAGE_SIZE_3264x2448 = 1;
+    static const int ID_IMAGE_SIZE_3264x1836 = 2;
+    static const int ID_IMAGE_SIZE_1920x1080 = 3;
 
-    enum id_video_size {
-        ID_VIDEO_SIZE_1920x1080x30 = 1,
-        ID_VIDEO_SIZE_1920x1080x15,
-        ID_VIDEO_SIZE_1280x720x30,
-        ID_VIDEO_SIZE_1280x720x15,
-        ID_VIDEO_SIZE_960x540x30,
-        ID_VIDEO_SIZE_960x540x15,
-        ID_VIDEO_SIZE_848x480x30,
-        ID_VIDEO_SIZE_848x480x15,
-        ID_VIDEO_SIZE_640x480x60,
-        ID_VIDEO_SIZE_640x480x30,
-        ID_VIDEO_SIZE_640x480x15,
-        ID_VIDEO_SIZE_640x360x30,
-        ID_VIDEO_SIZE_640x360x15,
-        ID_VIDEO_SIZE_424x240x30,
-        ID_VIDEO_SIZE_424x240x15,
-        ID_VIDEO_SIZE_320x240x60,
-        ID_VIDEO_SIZE_320x240x30,
-        ID_VIDEO_SIZE_320x240x15,
-        ID_VIDEO_SIZE_320x180x30,
-        ID_VIDEO_SIZE_320x180x60
-    };
+    // ID for video sizes
+    static const int ID_VIDEO_SIZE_1920x1080x30 = 1;
+    static const int ID_VIDEO_SIZE_1920x1080x15 = 2;
+    static const int ID_VIDEO_SIZE_1280x720x30 = 3;
+    static const int ID_VIDEO_SIZE_1280x720x15 = 4;
+    static const int ID_VIDEO_SIZE_960x540x30 = 5;
+    static const int ID_VIDEO_SIZE_960x540x15 = 6;
+    static const int ID_VIDEO_SIZE_848x480x30 = 7;
+    static const int ID_VIDEO_SIZE_848x480x15 = 8;
+    static const int ID_VIDEO_SIZE_640x480x60 = 9;
+    static const int ID_VIDEO_SIZE_640x480x30 = 10;
+    static const int ID_VIDEO_SIZE_640x480x15 = 11;
+    static const int ID_VIDEO_SIZE_640x360x30 = 12;
+    static const int ID_VIDEO_SIZE_640x360x15 = 13;
+    static const int ID_VIDEO_SIZE_424x240x30 = 14;
+    static const int ID_VIDEO_SIZE_424x240x15 = 15;
+    static const int ID_VIDEO_SIZE_320x240x60 = 16;
+    static const int ID_VIDEO_SIZE_320x240x30 = 17;
+    static const int ID_VIDEO_SIZE_320x240x15 = 18;
+    static const int ID_VIDEO_SIZE_320x180x30 = 19;
+    static const int ID_VIDEO_SIZE_320x180x60 = 20;
 
-    enum id_camera_mode { ID_CAMERA_MODE_STILL = 0, ID_CAMERA_MODE_VIDEO, ID_CAMERA_MODE_PREVIEW };
+    // ID for camera modes
+    static const int ID_CAMERA_MODE_STILL = 0;
+    static const int ID_CAMERA_MODE_VIDEO = 1;
+    static const int ID_CAMERA_MODE_PREVIEW = 2;
 
-    enum id_image_format { ID_IMAGE_FORMAT_JPEG = 0, ID_IMAGE_FORMAT_PNG };
+    // ID for image formats
+    static const int ID_IMAGE_FORMAT_RAW = 0;
+    static const int ID_IMAGE_FORMAT_JPEG = 1;
+    static const int ID_IMAGE_FORMAT_PNG = 2;
 
-    enum id_white_balance_mode {
-        ID_WHITE_BALANCE_MANUAL = 0,
-        ID_WHITE_BALANCE_AUTO,
-        ID_WHITE_BALANCE_INCANDESCENT,
-        ID_WHITE_BALANCE_FLUORESCENT,
-        ID_WHITE_BALANCE_WARM_FLUORESCENT,
-        ID_WHITE_BALANCE_DAYLIGHT,
-        ID_WHITE_BALANCE_CLOUDY_DAYLIGHT,
-        ID_WHITE_BALANCE_TWILIGHT,
-        ID_WHITE_BALANCE_SHADE
-    };
+    // ID for White Balance Modes
+    static const int ID_WHITE_BALANCE_MANUAL = 0;
+    static const int ID_WHITE_BALANCE_AUTO = 1;
+    static const int ID_WHITE_BALANCE_INCANDESCENT = 2;
+    static const int ID_WHITE_BALANCE_FLUORESCENT = 3;
+    static const int ID_WHITE_BALANCE_WARM_FLUORESCENT = 4;
+    static const int ID_WHITE_BALANCE_DAYLIGHT = 5;
+    static const int ID_WHITE_BALANCE_CLOUDY_DAYLIGHT = 6;
+    static const int ID_WHITE_BALANCE_TWILIGHT = 7;
+    static const int ID_WHITE_BALANCE_SHADE = 8;
 
-    enum id_exposure_mode { ID_EXPOSURE_MANUAL = 0, ID_EXPOSURE_AUTO };
+    // ID for exposure modes
+    static const int ID_EXPOSURE_MANUAL = 0;
+    static const int ID_EXPOSURE_AUTO = 1;
 
-    enum id_pixel_format {
-        ID_PIXEL_FORMAT_YUV422SP = 0,
-        ID_PIXEL_FORMAT_YUV420SP,
-        ID_PIXEL_FORMAT_YUV422I,
-        ID_PIXEL_FORMAT_YUV420P,
-        ID_PIXEL_FORMAT_RGB565,
-        ID_PIXEL_FORMAT_RGBA8888
-    };
+    // ID for pixel formats
+    static const int ID_PIXEL_FORMAT_YUV422SP = 0;
+    static const int ID_PIXEL_FORMAT_YUV420SP = 1;
+    static const int ID_PIXEL_FORMAT_YUV422I = 2;
+    static const int ID_PIXEL_FORMAT_YUV420P = 3;
+    static const int ID_PIXEL_FORMAT_RGB565 = 4;
+    static const int ID_PIXEL_FORMAT_RGBA8888 = 5;
 
     // TODO :: Make exhaustive list of parameters and its possible values
 private:
     void initParamIdType();
-    void set(std::map<std::string, std::string> &pMap, std::string key, std::string value);
-    void set(std::map<std::string, std::pair<int, int>> &pMap, std::string key,
-             std::pair<int, int> value);
-    std::string get(std::map<std::string, std::string> &pMap, std::string key);
     std::map<std::string, std::string> paramValue;
     std::map<std::string, std::string> paramValuesSupported;
     std::map<std::string, std::pair<int, int>> paramIdType; /*Key->ID,Type*/

--- a/src/CameraParameters.h
+++ b/src/CameraParameters.h
@@ -1,0 +1,189 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+#include "log.h"
+
+class CameraParameters {
+public:
+    CameraParameters();
+    virtual ~CameraParameters();
+    int getParameterType(std::string param);
+    int getParameterID(std::string param);
+    int setParameterSupported(std::string key, std::string value);
+    int setParameter(std::string param, std::string value);
+    std::string getParameter(std::string param);
+    const std::map<std::string, std::string> &getParameterList() const { return paramValue; }
+
+    enum param_type {
+        PARAM_TYPE_UINT8 = 1,
+        PARAM_TYPE_INT8,
+        PARAM_TYPE_UINT16,
+        PARAM_TYPE_INT16,
+        PARAM_TYPE_UINT32,
+        PARAM_TYPE_INT32,
+        PARAM_TYPE_UINT64,
+        PARAM_TYPE_INT64,
+        PARAM_TYPE_REAL32,
+        PARAM_TYPE_REAL64
+    };
+
+    // List of the params
+    static const char CAMERA_MODE[];
+    static const char BRIGHTNESS[];
+    static const char CONTRAST[];
+    static const char SATURATION[];
+    static const char HUE[];
+    static const char WHITE_BALANCE_MODE[];
+    static const char GAMMA[];
+    static const char GAIN[];
+    static const char POWER_LINE_FREQ_MODE[];
+    static const char WHITE_BALANCE_TEMPERATURE[];
+    static const char SHARPNESS[];
+    static const char BACKLIGHT_COMPENSATION[];
+    static const char EXPOSURE_MODE[];
+    static const char EXPOSURE_ABSOLUTE[];
+    static const char IMAGE_SIZE[];
+    static const char IMAGE_FORMAT[];
+    static const char PIXEL_FORMAT[];
+    static const char SCENE_MODE[];
+    static const char VIDEO_SIZE[];
+    static const char VIDEO_FRAME_FORMAT[];
+    static const char IMAGE_CAPTURE[];
+    static const char VIDEO_CAPTURE[];
+    static const char VIDEO_SNAPSHOT[];
+    static const char IMAGE_VIDEOSHOT[];
+
+    // Values for camera modes
+    static const char CAMERA_MODE_STILL[];
+    static const char CAMERA_MODE_VIDEO[];
+    static const char CAMERA_MODE_PREVIEW[];
+    // Values for white balance settings.
+    static const char WHITE_BALANCE_AUTO[];
+    static const char WHITE_BALANCE_INCANDESCENT[];
+    static const char WHITE_BALANCE_FLUORESCENT[];
+    static const char WHITE_BALANCE_WARM_FLUORESCENT[];
+    static const char WHITE_BALANCE_DAYLIGHT[];
+    static const char WHITE_BALANCE_CLOUDY_DAYLIGHT[];
+    static const char WHITE_BALANCE_TWILIGHT[];
+    static const char WHITE_BALANCE_SHADE[];
+    // Values for Pixel color formats
+    static const char PIXEL_FORMAT_YUV422SP[];
+    static const char PIXEL_FORMAT_YUV420SP[];
+    static const char PIXEL_FORMAT_YUV422I[];
+    static const char PIXEL_FORMAT_YUV420P[];
+    static const char PIXEL_FORMAT_RGB565[];
+    static const char PIXEL_FORMAT_RGBA8888[];
+    // Values for Image formats
+    static const char IMAGE_FORMAT_JPEG[];
+    static const char IMAGE_FORMAT_PNG[];
+
+    enum param_id {
+        PARAM_ID_CAMERA_MODE = 1,
+        PARAM_ID_BRIGHTNESS,
+        PARAM_ID_CONTRAST,
+        PARAM_ID_SATURATION,
+        PARAM_ID_HUE,
+        PARAM_ID_WHITE_BALANCE_MODE,
+        PARAM_ID_GAMMA,
+        PARAM_ID_GAIN,
+        PARAM_ID_POWER_LINE_FREQ_MODE,
+        PARAM_ID_WHITE_BALANCE_TEMPERATURE,
+        PARAM_ID_SHARPNESS,
+        PARAM_ID_BACKLIGHT_COMPENSATION,
+        PARAM_ID_EXPOSURE_MODE,
+        PARAM_ID_EXPOSURE_ABSOLUTE,
+        PARAM_ID_IMAGE_SIZE,
+        PARAM_ID_IMAGE_FORMAT,
+        PARAM_ID_PIXEL_FORMAT,
+        PARAM_ID_SCENE_MODE,
+        PARAM_ID_VIDEO_SIZE,
+        PARAM_ID_VIDEO_FRAME_FORMAT,
+        PARAM_ID_VIDEO_SNAPSHOT_SUPPORTED
+    };
+
+    enum id_image_size {
+        ID_IMAGE_SIZE_3264x2448 = 0,
+        ID_IMAGE_SIZE_3264x1836,
+        ID_IMAGE_SIZE_1920x1080
+    };
+
+    enum id_video_size {
+        ID_VIDEO_SIZE_1920x1080x30 = 1,
+        ID_VIDEO_SIZE_1920x1080x15,
+        ID_VIDEO_SIZE_1280x720x30,
+        ID_VIDEO_SIZE_1280x720x15,
+        ID_VIDEO_SIZE_960x540x30,
+        ID_VIDEO_SIZE_960x540x15,
+        ID_VIDEO_SIZE_848x480x30,
+        ID_VIDEO_SIZE_848x480x15,
+        ID_VIDEO_SIZE_640x480x60,
+        ID_VIDEO_SIZE_640x480x30,
+        ID_VIDEO_SIZE_640x480x15,
+        ID_VIDEO_SIZE_640x360x30,
+        ID_VIDEO_SIZE_640x360x15,
+        ID_VIDEO_SIZE_424x240x30,
+        ID_VIDEO_SIZE_424x240x15,
+        ID_VIDEO_SIZE_320x240x60,
+        ID_VIDEO_SIZE_320x240x30,
+        ID_VIDEO_SIZE_320x240x15,
+        ID_VIDEO_SIZE_320x180x30,
+        ID_VIDEO_SIZE_320x180x60
+    };
+
+    enum id_camera_mode { ID_CAMERA_MODE_STILL = 0, ID_CAMERA_MODE_VIDEO, ID_CAMERA_MODE_PREVIEW };
+
+    enum id_image_format { ID_IMAGE_FORMAT_JPEG = 0, ID_IMAGE_FORMAT_PNG };
+
+    enum id_white_balance_mode {
+        ID_WHITE_BALANCE_MANUAL = 0,
+        ID_WHITE_BALANCE_AUTO,
+        ID_WHITE_BALANCE_INCANDESCENT,
+        ID_WHITE_BALANCE_FLUORESCENT,
+        ID_WHITE_BALANCE_WARM_FLUORESCENT,
+        ID_WHITE_BALANCE_DAYLIGHT,
+        ID_WHITE_BALANCE_CLOUDY_DAYLIGHT,
+        ID_WHITE_BALANCE_TWILIGHT,
+        ID_WHITE_BALANCE_SHADE
+    };
+
+    enum id_exposure_mode { ID_EXPOSURE_MANUAL = 0, ID_EXPOSURE_AUTO };
+
+    enum id_pixel_format {
+        ID_PIXEL_FORMAT_YUV422SP = 0,
+        ID_PIXEL_FORMAT_YUV420SP,
+        ID_PIXEL_FORMAT_YUV422I,
+        ID_PIXEL_FORMAT_YUV420P,
+        ID_PIXEL_FORMAT_RGB565,
+        ID_PIXEL_FORMAT_RGBA8888
+    };
+
+    // TODO :: Make exhaustive list of parameters and its possible values
+private:
+    void initParamIdType();
+    void set(std::map<std::string, std::string> &pMap, std::string key, std::string value);
+    void set(std::map<std::string, std::pair<int, int>> &pMap, std::string key,
+             std::pair<int, int> value);
+    std::string get(std::map<std::string, std::string> &pMap, std::string key);
+    std::map<std::string, std::string> paramValue;
+    std::map<std::string, std::string> paramValuesSupported;
+    std::map<std::string, std::pair<int, int>> paramIdType; /*Key->ID,Type*/
+};

--- a/src/CameraParameters.h
+++ b/src/CameraParameters.h
@@ -75,7 +75,7 @@ public:
     // Values for camera modes
     static const char CAMERA_MODE_STILL[];
     static const char CAMERA_MODE_VIDEO[];
-    static const char CAMERA_MODE_PREVIEW[];
+    static const char CAMERA_MODE_IMAGE_SURVEY[];
     // Values for white balance settings.
     static const char WHITE_BALANCE_AUTO[];
     static const char WHITE_BALANCE_INCANDESCENT[];
@@ -152,7 +152,7 @@ public:
     // ID for camera modes
     static const int ID_CAMERA_MODE_STILL = 0;
     static const int ID_CAMERA_MODE_VIDEO = 1;
-    static const int ID_CAMERA_MODE_PREVIEW = 2;
+    static const int ID_CAMERA_MODE_IMAGE_SURVEY = 2;
 
     // ID for image formats
     static const int ID_IMAGE_FORMAT_RAW = 0;

--- a/src/CameraParameters.h
+++ b/src/CameraParameters.h
@@ -22,6 +22,9 @@
 
 #include "log.h"
 
+#define CAM_PARAM_ID_LEN 16
+#define CAM_PARAM_VALUE_LEN 128
+
 class CameraParameters {
 public:
     CameraParameters();
@@ -29,9 +32,21 @@ public:
     const std::map<std::string, std::string> &getParameterList() const { return paramValue; }
     bool setParameterSupported(std::string key, std::string value);
     bool setParameter(std::string param, std::string value);
+    bool setParameter(std::string param_id, float param_value);
+    bool setParameter(std::string param_id, uint32_t param_value);
+    bool setParameter(std::string param_id, int32_t param_value);
+    bool setParameter(std::string param_id, uint8_t param_value);
     std::string getParameter(std::string param);
     int getParameterType(std::string param);
     int getParameterID(std::string param);
+
+    union cam_param_union {
+        float param_float;
+        int32_t param_int32;
+        uint32_t param_uint32;
+        uint8_t param_uint8;
+        uint8_t bytes[4];
+    } cam_param_union_t;
 
     enum param_type {
         PARAM_TYPE_UINT8 = 1,

--- a/src/CameraParameters.h
+++ b/src/CameraParameters.h
@@ -40,12 +40,18 @@ public:
     int getParameterType(std::string param);
     int getParameterID(std::string param);
 
-    union cam_param_union {
-        float param_float;
-        int32_t param_int32;
-        uint32_t param_uint32;
-        uint8_t param_uint8;
-        uint8_t bytes[4];
+    typedef struct {
+        union {
+            float param_float;
+            int32_t param_int32;
+            uint32_t param_uint32;
+            int16_t param_int16;
+            uint16_t param_uint16;
+            int8_t param_int8;
+            uint8_t param_uint8;
+            uint8_t bytes[CAM_PARAM_VALUE_LEN];
+        };
+        uint8_t type;
     } cam_param_union_t;
 
     enum param_type {

--- a/src/CameraServer.cpp
+++ b/src/CameraServer.cpp
@@ -1,0 +1,172 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <cstring>
+#include <set>
+#include <sstream>
+#include <string.h>
+
+#include "CameraComponent_V4L2.h"
+#include "CameraServer.h"
+#include "log.h"
+#include "mavlink_server.h"
+#include "util.h"
+
+#define DEVICE_PATH "/dev/"
+#define VIDEO_PREFIX "video"
+#define DEFAULT_SERVICE_PORT 8554
+
+CameraServer::CameraServer(ConfFile &conf)
+    : mavlink_server(conf, streams, rtsp_server)
+    , rtsp_server(streams, DEFAULT_SERVICE_PORT)
+    , cameraCount(0)
+{
+    cameraCount = detectCamera(conf);
+
+    std::vector<CameraComponent *>::iterator it;
+    for (it = cameraList.begin(); it != cameraList.end(); it++) {
+        if (*it) {
+            mavlink_server.addCameraComponent(*it);
+        }
+    }
+}
+
+CameraServer::~CameraServer()
+{
+    stop();
+}
+
+void CameraServer::start()
+{
+    log_error("CAMERA SERVER START");
+
+    mavlink_server.start();
+}
+
+void CameraServer::stop()
+{
+    mavlink_server.stop();
+}
+
+// prepare the list of cameras in the system
+int CameraServer::detectCamera(ConfFile &conf)
+{
+    int count = 0;
+
+    count += detect_v4l2devices(conf, cameraList);
+
+    return count;
+}
+
+static void _insert(std::set<std::string> *value_set, const char *val, size_t val_len)
+{
+    while (isspace(*val) && val_len > 0) {
+        val++;
+        val_len--;
+    }
+
+    while (val_len > 0 && isspace(val[val_len - 1]))
+        val_len--;
+
+    if (val_len)
+        value_set->insert(std::string(val, val_len));
+}
+
+static int parse_stl_set(const char *val, size_t val_len, void *storage, size_t storage_len)
+{
+    assert(val);
+    assert(val_len);
+    assert(storage);
+
+    std::set<std::string> *value_set = (std::set<std::string> *)storage;
+    char *end;
+
+    while ((end = (char *)memchr((void *)val, ',', val_len))) {
+        if (end - val)
+            _insert(value_set, val, end - val);
+        val_len = val_len - (end - val) - 1;
+        val = end + 1;
+    }
+    if (val_len)
+        _insert(value_set, val, val_len);
+
+    return 0;
+}
+
+static int parse_uri(ConfFile &conf, const char *key, char *value)
+{
+    struct options {
+        char *uri_addr;
+    } opt;
+
+    static const ConfFile::OptionsTable option_table[] = {
+        {key, false, ConfFile::parse_str_dup, OPTIONS_TABLE_STRUCT_FIELD(options, uri_addr)},
+    };
+    conf.extract_options("uri", option_table, ARRAY_SIZE(option_table), (void *)&opt);
+    if (!opt.uri_addr) {
+        log_error("URI of camera definition file for %s not found", key);
+        return 0;
+    }
+
+    log_debug("%s URI : %s", key, opt.uri_addr);
+    strcpy(value, opt.uri_addr);
+    free(opt.uri_addr);
+    return 1;
+}
+
+int CameraServer::detect_v4l2devices(ConfFile &conf, std::vector<CameraComponent *> &camList)
+{
+    int count = 0;
+    char uri[140];
+    DIR *dp;
+    struct dirent *ep;
+
+    std::set<std::string> blacklist;
+    static const ConfFile::OptionsTable option_table[] = {
+        {"blacklist", false, parse_stl_set, 0, 0},
+    };
+
+    conf.extract_options("v4l2", option_table, 1, (void *)&blacklist);
+
+    dp = opendir(DEVICE_PATH);
+    if (dp == NULL) {
+        log_error("Could not open directory");
+        return 0;
+    }
+
+    while ((ep = readdir(dp))) {
+        if (std::strncmp(VIDEO_PREFIX, ep->d_name, sizeof(VIDEO_PREFIX) - 1) == 0) {
+            std::string dev_path = DEVICE_PATH;
+            // Don't add stream if it is in a blacklist
+            if (blacklist.find(ep->d_name) != blacklist.end())
+                continue;
+            log_debug("Found V4L2 camera device %s", ep->d_name);
+            dev_path.append(ep->d_name);
+            // TODO::Get the URI for the specific camera device from conf file
+            if (parse_uri(conf, ep->d_name, uri))
+                camList.push_back(new CameraComponent_V4L2(dev_path, uri));
+            else
+                camList.push_back(new CameraComponent_V4L2(dev_path));
+            count++;
+        }
+    }
+
+    closedir(dp);
+    return count;
+}

--- a/src/CameraServer.h
+++ b/src/CameraServer.h
@@ -1,0 +1,47 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+#include "conf_file.h"
+#include "mavlink_server.h"
+#include "rtsp_server.h"
+#include "stream.h"
+
+#include "CameraComponent.h"
+#include "log.h"
+
+class CameraServer {
+public:
+    CameraServer(ConfFile &conf);
+    ~CameraServer();
+    void start();
+    void stop();
+    int getCameraCount() { return cameraCount; }
+
+private:
+    int detectCamera(ConfFile &conf);
+    int detect_v4l2devices(ConfFile &conf, std::vector<CameraComponent *> &cameraList);
+    MavlinkServer mavlink_server;
+    RTSPServer rtsp_server;
+    int cameraCount;
+    std::vector<CameraComponent *> cameraList;
+    std::vector<std::unique_ptr<Stream>> streams; // Remove it
+};

--- a/src/conf_file.h
+++ b/src/conf_file.h
@@ -102,6 +102,17 @@ public:
                         void *data);
 
     /**
+     * Extract option set in @a field from section @a section_name
+     *
+     * @param section_name Name of the section to extract options.
+     * @param key Name of the field that need to be extracted
+     * @param value A double pointer to char used to output the address of the value extracted.
+     * On success, value holds pointer to null terminated string.
+     * Caller must free the memory allocated for value
+     */
+    int extract_options(const char *section_name, const char *key, char **value);
+
+    /**
      * Get next section name from iterator that matches the shell wildcard @a pattern.
      *
      * If iter.ptr is @c nullptr get_sections() will look for first occurence of @a pattern in
@@ -120,6 +131,7 @@ public:
 
     // Helpers
     static int parse_bool(const char *val, size_t val_len, void *storage, size_t storage_len);
+    static int parse_stl_set(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_str_dup(const char *val, size_t val_len, void *storage, size_t storage_len);
     static int parse_str_buf(const char *val, size_t val_len, void *storage, size_t storage_len);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,9 @@
 #include "settings.h"
 #include "stream_manager.h"
 #include "util.h"
+#ifdef ENABLE_MAVLINK
+#include "CameraServer.h"
+#endif
 
 #define DEFAULT_CONFFILE "/etc/csd/main.conf"
 #define DEFAULT_CONF_DIR "/etc/csd/config.d"
@@ -239,11 +242,17 @@ int main(int argc, char *argv[])
     conf = new ConfFile();
     parse_conf_files(*conf, &opt);
 
-    StreamManager stream(*conf);
-    delete conf;
+#ifdef ENABLE_MAVLINK
+    CameraServer camServer(*conf);
+    camServer.start();
+#endif
 
-    log_debug("Starting Camera Streaming Daemon");
+    StreamManager stream(*conf);
     stream.start();
+
+    delete conf;
+    log_debug("Starting Camera Streaming Daemon");
+
     mainloop.loop();
 
     Log::close();

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -187,10 +187,12 @@ void MavlinkServer::_handle_request_storage_information(const struct sockaddr_in
     CameraComponent *tgtComp = getCameraComponent(cmd.target_component);
     if (tgtComp) {
         // TODO:: Fill with appropriate value
-        mavlink_msg_storage_information_pack(
-            _system_id, cmd.target_component, &msg, 0, 1 /*storage_id*/, 1 /*storage_count*/,
-            2 /*status- formatted*/, 50.0 /*total_capacity*/, 0.0 /*used_capacity*/,
-            50.0 /*available_capacity*/, 128 /*read_speed*/, 128 /*write_speed*/);
+        const StorageInfo &storeInfo = tgtComp->getStorageInfo();
+        mavlink_msg_storage_information_pack(_system_id, cmd.target_component, &msg, 0,
+                                             storeInfo.storage_id, storeInfo.storage_count,
+                                             storeInfo.status, storeInfo.total_capacity,
+                                             storeInfo.used_capacity, storeInfo.available_capacity,
+                                             storeInfo.read_speed, storeInfo.write_speed);
 
         if (!_send_mavlink_message(&addr, msg)) {
             log_error("Sending storage information failed for camera %d.", cmd.target_component);

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -208,6 +208,23 @@ void MavlinkServer::_handle_request_storage_information(const struct sockaddr_in
     _send_ack(addr, cmd.command, cmd.target_component, success);
 }
 
+void MavlinkServer::_handle_set_camera_mode(const struct sockaddr_in &addr,
+                                                        mavlink_command_long_t &cmd)
+{
+    log_debug("%s", __func__);
+
+    bool success = false;
+
+    CameraComponent *tgtComp = getCameraComponent(cmd.target_component);
+    if (tgtComp) {
+        if(!tgtComp->setCameraMode((uint32_t)cmd.param2))
+            success = true;
+    }
+
+    _send_ack(addr, cmd.command, cmd.target_component, success);
+
+}
+
 void MavlinkServer::_handle_camera_video_stream_request(const struct sockaddr_in &addr, int command,
                                                         unsigned int camera_id, unsigned int action)
 {
@@ -444,6 +461,8 @@ void MavlinkServer::_handle_mavlink_message(const struct sockaddr_in &addr, mavl
             log_debug("MAV_CMD_STORAGE_FORMAT");
             break;
         case MAV_CMD_SET_CAMERA_MODE:
+            this->_handle_set_camera_mode(addr, cmd);
+            break;
         case MAV_CMD_IMAGE_START_CAPTURE:
         case MAV_CMD_IMAGE_STOP_CAPTURE:
         case MAV_CMD_REQUEST_CAMERA_IMAGE_CAPTURE:

--- a/src/mavlink_server.cpp
+++ b/src/mavlink_server.cpp
@@ -436,11 +436,13 @@ void MavlinkServer::_handle_param_ext_set(const struct sockaddr_in &addr, mavlin
                                 param_set.param_value, sizeof(param_set.param_value),
                                 param_set.param_type);
         // Copy id from req msg to response msg
-        strncpy(param_ext_ack.param_id, param_set.param_id, sizeof(param_ext_ack.param_id));
+        mem_cpy(param_ext_ack.param_id, sizeof(param_ext_ack.param_id), param_set.param_id,
+                sizeof(param_set.param_id), sizeof(param_ext_ack.param_id));
         param_ext_ack.param_type = param_set.param_type;
         if (!ret) {
             // Send response to GCS
-            strncpy(param_ext_ack.param_value, param_set.param_value,
+            mem_cpy(param_ext_ack.param_value, sizeof(param_ext_ack.param_value),
+                    param_set.param_value, sizeof(param_set.param_value),
                     sizeof(param_ext_ack.param_value));
             param_ext_ack.param_result = PARAM_ACK_ACCEPTED;
         } else {

--- a/src/mavlink_server.h
+++ b/src/mavlink_server.h
@@ -58,6 +58,8 @@ private:
                                          mavlink_command_long_t &cmd);
     void _handle_request_storage_information(const struct sockaddr_in &addr,
                                              mavlink_command_long_t &cmd);
+    void _handle_set_camera_mode(const struct sockaddr_in &addr,
+                                                        mavlink_command_long_t &cmd);
     void _handle_camera_video_stream_request(const struct sockaddr_in &addr, int command,
                                              unsigned int camera_id, unsigned int action);
     void _handle_camera_set_video_stream_settings(const struct sockaddr_in &addr,

--- a/src/mavlink_server.h
+++ b/src/mavlink_server.h
@@ -60,6 +60,8 @@ private:
                                              mavlink_command_long_t &cmd);
     void _handle_set_camera_mode(const struct sockaddr_in &addr,
                                                         mavlink_command_long_t &cmd);
+    void _handle_request_camera_capture_status(const struct sockaddr_in &addr,
+                                               mavlink_command_long_t &cmd);
     void _handle_camera_video_stream_request(const struct sockaddr_in &addr, int command,
                                              unsigned int camera_id, unsigned int action);
     void _handle_camera_set_video_stream_settings(const struct sockaddr_in &addr,

--- a/src/mavlink_server.h
+++ b/src/mavlink_server.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <vector>
 
+#include "CameraComponent.h"
 #include "conf_file.h"
 #include "rtsp_server.h"
 #include "socket.h"
@@ -33,6 +34,9 @@ public:
     ~MavlinkServer();
     void start();
     void stop();
+    int addCameraComponent(CameraComponent *camComp);
+    void removeCameraComponent(CameraComponent *camComp);
+    CameraComponent *getCameraComponent(int compID);
 
 private:
     const std::vector<std::unique_ptr<Stream>> &_streams;
@@ -44,17 +48,25 @@ private:
     int _comp_id;
     char *_rtsp_server_addr;
     RTSPServer &_rtsp;
+    std::map<int, CameraComponent *> compIdToObj;
 
     void _message_received(const struct sockaddr_in &sockaddr, const struct buffer &buf);
     void _handle_mavlink_message(const struct sockaddr_in &addr, mavlink_message_t *msg);
-    void _handle_camera_info_request(const struct sockaddr_in &addr, int command,
-                                     unsigned int camera_id, unsigned int action);
+    void _handle_request_camera_information(const struct sockaddr_in &addr,
+                                            mavlink_command_long_t &cmd);
+    void _handle_request_camera_settings(const struct sockaddr_in &addr,
+                                         mavlink_command_long_t &cmd);
+    void _handle_request_storage_information(const struct sockaddr_in &addr,
+                                             mavlink_command_long_t &cmd);
     void _handle_camera_video_stream_request(const struct sockaddr_in &addr, int command,
                                              unsigned int camera_id, unsigned int action);
     void _handle_camera_set_video_stream_settings(const struct sockaddr_in &addr,
                                                   mavlink_message_t *msg);
+    void _handle_param_ext_request_read(const struct sockaddr_in &addr, mavlink_message_t *msg);
+    void _handle_param_ext_request_list(const struct sockaddr_in &addr, mavlink_message_t *msg);
+    void _handle_param_ext_set(const struct sockaddr_in &addr, mavlink_message_t *msg);
     bool _send_mavlink_message(const struct sockaddr_in *addr, mavlink_message_t &msg);
-    void _send_ack(const struct sockaddr_in &addr, int cmd, bool success);
+    void _send_ack(const struct sockaddr_in &addr, int cmd, int comp_id, bool success);
     const Stream::FrameSize *_find_best_frame_size(Stream &s, uint32_t w, uint32_t v);
     friend bool _heartbeat_cb(void *data);
 };

--- a/src/stream_builder_v4l2.cpp
+++ b/src/stream_builder_v4l2.cpp
@@ -30,41 +30,6 @@
 
 static StreamBuilderV4l2 stream_builder;
 
-static void _insert(std::set<std::string> *value_set, const char *val, size_t val_len)
-{
-    while (isspace(*val) && val_len > 0) {
-        val++;
-        val_len--;
-    }
-
-    while (val_len > 0 && isspace(val[val_len - 1]))
-        val_len--;
-
-    if (val_len)
-        value_set->insert(std::string(val, val_len));
-}
-
-static int parse_stl_set(const char *val, size_t val_len, void *storage, size_t storage_len)
-{
-    assert(val);
-    assert(val_len);
-    assert(storage);
-
-    std::set<std::string> *value_set = (std::set<std::string> *)storage;
-    char *end;
-
-    while ((end = (char *)memchr((void *)val, ',', val_len))) {
-        if (end - val)
-            _insert(value_set, val, end - val);
-        val_len = val_len - (end - val) - 1;
-        val = end + 1;
-    }
-    if (val_len)
-        _insert(value_set, val, val_len);
-
-    return 0;
-}
-
 std::vector<Stream *> StreamBuilderV4l2::build_streams(ConfFile &conf)
 {
     DIR *dir;
@@ -73,7 +38,7 @@ std::vector<Stream *> StreamBuilderV4l2::build_streams(ConfFile &conf)
     std::set<std::string> blacklist;
 
     static const ConfFile::OptionsTable option_table[] = {
-        {"blacklist", false, parse_stl_set, 0, 0},
+        {"blacklist", false, ConfFile::parse_stl_set, 0, 0},
     };
 
     conf.extract_options("v4l2", option_table, 1, (void *)&blacklist);

--- a/src/stream_manager.cpp
+++ b/src/stream_manager.cpp
@@ -61,9 +61,6 @@ void StreamManager::start()
 #ifndef DISABLE_AVAHI
     avahi_publisher.start();
 #endif
-#ifdef ENABLE_MAVLINK
-    mavlink_server.start();
-#endif
 }
 
 void StreamManager::stop()
@@ -75,9 +72,6 @@ void StreamManager::stop()
     rtsp_server.stop();
 #ifndef DISABLE_AVAHI
     avahi_publisher.stop();
-#endif
-#ifdef ENABLE_MAVLINK
-    mavlink_server.stop();
 #endif
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -162,3 +162,19 @@ int mkdir_p(const char *path, int len, mode_t mode)
 
     return 0;
 }
+
+size_t mem_cpy(void *dest, size_t dsize, const void *src, size_t ssize, size_t cnt)
+{
+    size_t ncopy = 0;
+
+    if (dest == NULL || src == NULL)
+        return 0;
+
+    if (dsize == 0 || ssize == 0 || cnt == 0)
+        return 0;
+
+    ncopy = MIN(MIN(dsize, ssize), cnt);
+    memmove(dest, src, ncopy);
+
+    return ncopy;
+}

--- a/src/util.h
+++ b/src/util.h
@@ -46,6 +46,14 @@ typedef uint64_t nsec_t;
 #define strncaseeq(a, b, len) (strncasecmp((a), (b), (len)) == 0)
 #define memcaseeq(a, len_a, b, len_b) ((len_a) == (len_b) && strncaseeq(a, b, len_a))
 
+#ifndef MAX
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef MIN
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
 int safe_atoull(const char *s, unsigned long long *ret);
 int safe_atoul(const char *s, unsigned long *ret);
 int safe_atoi(const char *s, int *ret);
@@ -53,6 +61,9 @@ usec_t now_usec(void);
 usec_t ts_usec(const struct timespec *ts);
 
 int mkdir_p(const char *path, int len, mode_t mode);
+
+size_t mem_cpy(void *dest, size_t dsize, const void *src, size_t ssize, size_t cnt);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/v4l2_interface.cpp
+++ b/src/v4l2_interface.cpp
@@ -1,0 +1,199 @@
+/*
+ * This file is part of the Camera Streaming Daemon project
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cerrno>
+#include <cstring>
+#include <dirent.h>
+#include <fcntl.h>
+#include <linux/videodev2.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include "log.h"
+#include "v4l2_interface.h"
+
+int v4l2_ioctl(int fd, int request, void *arg)
+{
+    int r;
+
+    do
+        r = ioctl(fd, request, arg);
+    while (-1 == r && EINTR == errno);
+
+    return r;
+}
+
+int v4l2_list_devices(std::vector<std::string> &devList)
+{
+    DIR *dp;
+    struct dirent *ep;
+
+    dp = opendir(V4L2_DEVICE_PATH);
+    if (dp == NULL) {
+        log_error("Could not open directory %d", errno);
+        return -1;
+    }
+
+    while ((ep = readdir(dp))) {
+        if (std::strncmp(V4L2_VIDEO_PREFIX, ep->d_name, sizeof(V4L2_VIDEO_PREFIX) - 1) == 0) {
+            log_debug("Found V4L2 camera device %s", ep->d_name);
+            // add device path to list
+            devList.push_back(std::string(V4L2_DEVICE_PATH) + ep->d_name);
+        }
+    }
+
+    closedir(dp);
+    return 0;
+}
+
+int v4l2_open(const char *devicepath)
+{
+    int fd = -1;
+    fd = open(devicepath, O_RDWR, 0);
+    if (fd < 0) {
+        log_error("Cannot open device '%s': %d: ", devicepath, errno);
+    }
+
+    return fd;
+}
+
+int v4l2_close(int fd)
+{
+    if (fd < 1)
+        return -1;
+
+    close(fd);
+    return 0;
+}
+
+int v4l2_query_cap(int fd)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    struct v4l2_capability vcap;
+    ret = v4l2_ioctl(fd, VIDIOC_QUERYCAP, &vcap);
+    if (ret)
+        return ret;
+
+    log_debug("\tDriver name   : %s", vcap.driver);
+    log_debug("\tCard type     : %s", vcap.card);
+    log_debug("\tBus info      : %s", vcap.bus_info);
+    log_debug("\tDriver version: %d.%d.%d", vcap.version >> 16, (vcap.version >> 8) & 0xff,
+              vcap.version & 0xff);
+    log_debug("\tCapabilities  : 0x%08X", vcap.capabilities);
+    if (vcap.capabilities & V4L2_CAP_DEVICE_CAPS) {
+        log_debug("\tDevice Caps   : 0x%08X", vcap.device_caps);
+    }
+    // TODO:: Return the caps
+    return 0;
+}
+
+int v4l2_query_control(int fd)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    const unsigned next_fl = V4L2_CTRL_FLAG_NEXT_CTRL | V4L2_CTRL_FLAG_NEXT_COMPOUND;
+    struct v4l2_control ctrl = {0};
+    struct v4l2_queryctrl qctrl = {0};
+    qctrl.id = next_fl;
+    while (v4l2_ioctl(fd, VIDIOC_QUERYCTRL, &qctrl) == 0) {
+        if ((qctrl.flags & V4L2_CTRL_TYPE_BOOLEAN) || (qctrl.type & V4L2_CTRL_TYPE_INTEGER)) {
+            log_debug("Ctrl: %s Min:%d Max:%d Step:%d dflt:%d", qctrl.name, qctrl.minimum,
+                      qctrl.maximum, qctrl.step, qctrl.default_value);
+            ctrl.id = qctrl.id;
+            if (v4l2_ioctl(fd, VIDIOC_G_CTRL, &ctrl) == 0) {
+                log_debug("Ctrl: %s Id:%x Value:%d\n", qctrl.name, ctrl.id, ctrl.value);
+            }
+        }
+        qctrl.id |= next_fl;
+    }
+    // TODO:: Return the list of controls
+    return 0;
+}
+
+int v4l2_query_framesizes(int fd)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    struct v4l2_fmtdesc fmt = {};
+    struct v4l2_frmsizeenum frame_size = {};
+    fmt.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    fmt.index = 0;
+    while (v4l2_ioctl(fd, VIDIOC_ENUM_FMT, &fmt) != -1) {
+        // TODO:: Save the format in some DS
+        log_debug("Pixel Format: %u", fmt.pixelformat);
+        log_debug("Name : %s\n", fmt.description);
+        frame_size.index = 0;
+        frame_size.pixel_format = fmt.pixelformat;
+        while (v4l2_ioctl(fd, VIDIOC_ENUM_FRAMESIZES, &frame_size) != -1) {
+            switch (frame_size.type) {
+            case V4L2_FRMSIZE_TYPE_DISCRETE:
+                log_debug(" FrameSize: %ux%u\n", frame_size.discrete.width,
+                          frame_size.discrete.height);
+                break;
+            case V4L2_FRMSIZE_TYPE_CONTINUOUS:
+            case V4L2_FRMSIZE_TYPE_STEPWISE:
+                log_debug(" FrameSize: %ux%u -> %ux%u\n", frame_size.stepwise.min_width,
+                          frame_size.stepwise.min_height, frame_size.stepwise.max_width,
+                          frame_size.stepwise.max_height);
+                break;
+            }
+            // TODO::Save the framesizes against format in some DS
+        }
+
+        fmt.index++;
+    }
+
+    // TODO::Return the list of pixformats & framesizes
+    return 0;
+}
+
+int v4l2_get_control(int fd, int ctrl_id)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    struct v4l2_control ctrl = {0};
+    ctrl.id = ctrl_id;
+    ret = v4l2_ioctl(fd, VIDIOC_G_CTRL, &ctrl);
+    if (ret == 0)
+        return ctrl.value;
+    else
+        return ret;
+}
+
+int v4l2_set_control(int fd, int ctrl_id, int value)
+{
+    int ret = -1;
+    if (fd < 1)
+        return ret;
+
+    struct v4l2_control c = {0};
+    c.id = ctrl_id;
+    c.value = value;
+    ret = v4l2_ioctl(fd, VIDIOC_S_CTRL, &c);
+
+    return ret;
+}

--- a/src/v4l2_interface.h
+++ b/src/v4l2_interface.h
@@ -1,0 +1,33 @@
+/*
+ * This file is part of the Camera Streaming Daemon project
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <string>
+#include <vector>
+
+#define V4L2_DEVICE_PATH "/dev/"
+#define V4L2_VIDEO_PREFIX "video"
+
+int v4l2_ioctl(int fd, int request, void *arg);
+int v4l2_list_devices(std::vector<std::string> &devList);
+int v4l2_open(const char *devicepath);
+int v4l2_close(int fd);
+int v4l2_query_cap(int fd);
+int v4l2_query_control(int fd);
+int v4l2_query_framesizes(int fd);
+int v4l2_get_control(int fd, int ctrl_id);
+int v4l2_set_control(int fd, int ctrl_id, int value);


### PR DESCRIPTION
This change is to enable users to controls the camera parameters.

- Details on how the camera parameters will be exposed by the camera(drone) to ground control station, how GCS will communicate with drone to set/get camera params can be found here - http://discuss.px4.io/t/mavlink-camera-api-discussion/3278/31.

- Changes on the QGC for this feature can be found here - https://github.com/mavlink/qgroundcontrol/tree/cameraControl