### PR TITLE
Add support for Gazebo SITL camera

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,7 +70,8 @@ AM_CFLAGS = \
 	-fvisibility=hidden \
 	-ffunction-sections \
 	-fdata-sections \
-	${GST_CFLAGS}
+	${GST_CFLAGS} \
+	${GZB_CFLAGS}
 
 AM_CXXFLAGS = \
 	-I$(top_builddir)/src \
@@ -110,7 +111,8 @@ AM_CXXFLAGS = \
 	-fvisibility=hidden \
 	-ffunction-sections \
 	-fdata-sections \
-	${GST_CFLAGS}
+	${GST_CFLAGS} \
+	${GZB_CFLAGS}
 
 AM_LDFLAGS = \
 	-Wl,--as-needed \
@@ -180,7 +182,7 @@ csd_SOURCES = \
 	${BASE_FILES} \
 	src/main.cpp
 
-csd_LDADD = $(GLIB_LIBS) $(GST_LIBS)
+csd_LDADD = $(GLIB_LIBS) $(GST_LIBS) $(GZB_LIBS)
 
 CLEANFILES += csd.service
 
@@ -262,7 +264,9 @@ BASE_FILES += \
 	src/CameraDeviceV4l2.h \
 	src/ImageCapture.h \
 	src/ImageCaptureGst.h \
-	src/ImageCaptureGst.cpp
+	src/ImageCaptureGst.cpp \
+	src/CameraDeviceGazebo.h \
+	src/CameraDeviceGazebo.cpp
 
 samples_camera_sample_mavlink_client_SOURCES = \
 	samples/main_sample_mavlink_client.cpp \

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,8 +70,7 @@ AM_CFLAGS = \
 	-fvisibility=hidden \
 	-ffunction-sections \
 	-fdata-sections \
-	${GST_CFLAGS} \
-	${GZB_CFLAGS}
+	${GST_CFLAGS}
 
 AM_CXXFLAGS = \
 	-I$(top_builddir)/src \
@@ -111,8 +110,7 @@ AM_CXXFLAGS = \
 	-fvisibility=hidden \
 	-ffunction-sections \
 	-fdata-sections \
-	${GST_CFLAGS} \
-	${GZB_CFLAGS}
+	${GST_CFLAGS}
 
 AM_LDFLAGS = \
 	-Wl,--as-needed \
@@ -264,9 +262,19 @@ BASE_FILES += \
 	src/CameraDeviceV4l2.h \
 	src/ImageCapture.h \
 	src/ImageCaptureGst.h \
-	src/ImageCaptureGst.cpp \
+	src/ImageCaptureGst.cpp
+
+if ENABLE_GAZEBO
+AM_CFLAGS += \
+        ${GZB_CFLAGS}
+
+AM_CXXFLAGS += \
+        ${GZB_CFLAGS}
+
+BASE_FILES += \
 	src/CameraDeviceGazebo.h \
 	src/CameraDeviceGazebo.cpp
+endif
 
 samples_camera_sample_mavlink_client_SOURCES = \
 	samples/main_sample_mavlink_client.cpp \

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_INIT([camera-streaming-daemon],
 PKG_CHECK_MODULES(GLIB, [glib-2.0])
 PKG_CHECK_MODULES(AVAHI, [avahi-client, avahi-core, avahi-glib])
 PKG_CHECK_MODULES(GST, [gstreamer-rtsp-1.0, gstreamer-1.0, gstreamer-rtsp-server-1.0 gstreamer-app-1.0])
+PKG_CHECK_MODULES(GZB, [gazebo])
 
 AC_CONFIG_SRCDIR([src/main.cpp])
 AC_CONFIG_MACRO_DIR([m4])

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,6 @@ AC_INIT([camera-streaming-daemon],
 PKG_CHECK_MODULES(GLIB, [glib-2.0])
 PKG_CHECK_MODULES(AVAHI, [avahi-client, avahi-core, avahi-glib])
 PKG_CHECK_MODULES(GST, [gstreamer-rtsp-1.0, gstreamer-1.0, gstreamer-rtsp-server-1.0 gstreamer-app-1.0])
-PKG_CHECK_MODULES(GZB, [gazebo])
 
 AC_CONFIG_SRCDIR([src/main.cpp])
 AC_CONFIG_MACRO_DIR([m4])
@@ -55,6 +54,20 @@ AC_ARG_ENABLE([avahi],
  [
    enable_avahi=yes
    AM_CONDITIONAL([DISABLE_AVAHI], false)
+ ])
+
+
+AC_ARG_ENABLE([gazebo],
+ AS_HELP_STRING([--enable-gazebo], [Enable Gazebo Simulator Mode]),
+ [
+   PKG_CHECK_MODULES(GZB, [gazebo])
+   enable_gazebo=yes
+   AM_CONDITIONAL([ENABLE_GAZEBO], true)
+   AC_DEFINE(ENABLE_GAZEBO, 1, [Enable Gazebo Simulator Mode])
+ ],
+ [
+   enable_gazebo=no
+   AM_CONDITIONAL([ENABLE_GAZEBO], false)
  ])
 
 
@@ -167,4 +180,5 @@ AC_MSG_RESULT([
     MAVLink support:     $enable_mavlink
     AVAHI support:       $enable_avahi
     Intel Aero support:  $enable_aero
+    Gazebo support:      $enable_gazebo
 ])

--- a/src/CameraComponent.cpp
+++ b/src/CameraComponent.cpp
@@ -295,6 +295,13 @@ int CameraComponent::getCameraMode()
 int CameraComponent::startImageCapture(int interval, int count, capture_callback_t cb)
 {
     mImgCapCB = cb;
+
+    // Delete imgCap instance if already exists
+    // This could be because of no StopImageCapture call after done
+    // Or new startImageCapture call while prev call is still not done
+    if (mImgCap)
+        mImgCap.reset();
+
     mImgCap = std::make_shared<ImageCaptureGst>(mCamDev);
     if (!mImgPath.empty())
         mImgCap->setLocation(mImgPath);

--- a/src/CameraDevice.h
+++ b/src/CameraDevice.h
@@ -44,6 +44,7 @@ public:
 
     virtual std::string getDeviceId() = 0;
     virtual int getInfo(struct CameraInfo &camInfo) = 0;
+    virtual bool isGstV4l2Src() = 0;
     virtual int init(CameraParameters &camParam) = 0;
     virtual int uninit() = 0;
     virtual int start() { return -ENOTSUP; }

--- a/src/CameraDevice.h
+++ b/src/CameraDevice.h
@@ -58,7 +58,9 @@ public:
     virtual int setParam(std::string param_id, uint32_t param_value) { return -ENOTSUP; }
     virtual int setParam(std::string param_id, uint8_t param_value) { return -ENOTSUP; }
     virtual int setSize(uint32_t width, uint32_t height) { return -ENOTSUP; }
+    virtual int getSize(uint32_t &width, uint32_t &height) { return -ENOTSUP; }
     virtual int setPixelFormat(uint32_t format) { return -ENOTSUP; }
+    virtual int getPixelFormat(uint32_t &format) { return -ENOTSUP; }
     virtual int setMode(uint32_t mode) { return -ENOTSUP; }
     virtual int getMode() { return -ENOTSUP; };
     virtual int setBrightness(uint32_t value) { return -ENOTSUP; }

--- a/src/CameraDeviceGazebo.cpp
+++ b/src/CameraDeviceGazebo.cpp
@@ -1,0 +1,156 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gazebo/common/Image.hh>
+#include <gazebo/common/common.hh>
+#include <gazebo/gazebo_client.hh>
+#include <gazebo/msgs/msgs.hh>
+
+#include <iostream>
+
+#include "CameraDeviceGazebo.h"
+
+CameraDeviceGazebo::CameraDeviceGazebo(std::string device)
+    : mDeviceId(device)
+    , mWidth(0)
+    , mHeight(0)
+    , mPixelFormat(-1)
+{
+    log_debug("%s path:%s", __func__, mDeviceId.c_str());
+}
+
+CameraDeviceGazebo::~CameraDeviceGazebo()
+{
+    stop();
+    uninit();
+}
+
+std::string CameraDeviceGazebo::getDeviceId()
+{
+    return mDeviceId;
+}
+
+int CameraDeviceGazebo::getInfo(struct CameraInfo &camInfo)
+{
+    strcpy((char *)camInfo.vendorName, "Gazebo");
+    strcpy((char *)camInfo.modelName, "SITL-Camera");
+    camInfo.firmware_version = 1;
+    camInfo.focal_length = 0;
+    camInfo.sensor_size_h = 0;
+    camInfo.sensor_size_v = 0;
+    camInfo.resolution_h = 0;
+    camInfo.resolution_v = 0;
+    camInfo.lens_id = 0;
+    camInfo.flags = ~0u;
+    camInfo.cam_definition_version = 1;
+    return 0;
+}
+
+int CameraDeviceGazebo::init(CameraParameters &camParam)
+{
+    return 0;
+}
+
+int CameraDeviceGazebo::uninit()
+{
+    return 0;
+}
+
+int CameraDeviceGazebo::start()
+{
+    // Load Gazebo
+    gazebo::client::setup();
+
+    // Create our node for communication
+    mNode.reset(new gazebo::transport::Node());
+    mNode->Init();
+
+    // TODO:: Get the number of buffers that gazebo camera has
+    // TODO:: Initialize size of mFrameBuffer based on that
+
+    // Listen to Gazebo <device> topic
+    mSub = mNode->Subscribe(mDeviceId, &CameraDeviceGazebo::cbOnImages, this);
+    return 0;
+}
+
+int CameraDeviceGazebo::stop()
+{
+    // Make sure to shut everything down.
+    gazebo::client::shutdown();
+    return 0;
+}
+
+std::vector<uint8_t> CameraDeviceGazebo::read()
+{
+    std::lock_guard<std::mutex> locker(mLock);
+    return mFrameBuffer;
+}
+
+void CameraDeviceGazebo::cbOnImages(ConstImagesStampedPtr &_msg)
+{
+    std::lock_guard<std::mutex> locker(mLock);
+
+    log_debug("Image Count: %d", _msg->image_size());
+    for (int i = 0; i < _msg->image_size(); ++i) {
+        getImage(_msg->image(i));
+    }
+}
+
+int CameraDeviceGazebo::getImage(const gazebo::msgs::Image &_msg)
+{
+    int success = 0;
+    int failure = 1;
+
+    if (_msg.width() == 0 || _msg.height() == 0)
+        return failure;
+
+    log_debug("Width: %u", _msg.width());
+    log_debug("Height: %u", _msg.height());
+
+    int pixFormat;
+    switch (_msg.pixel_format()) {
+    case gazebo::common::Image::L_INT8:
+    case gazebo::common::Image::L_INT16: {
+        log_error("Pixel Format Mono :: Unsupported");
+        return failure;
+    }
+    case gazebo::common::Image::RGB_INT8:
+    case gazebo::common::Image::RGBA_INT8: {
+        pixFormat = CameraParameters::ID_PIXEL_FORMAT_RGB24;
+        break;
+    }
+    default: {
+        log_error("Pixel Format %d :: Unsupported", _msg.pixel_format());
+        return failure;
+    }
+    }
+
+    // copy image data to frame buffer
+    log_debug("Image Size: %lu Format:%d", _msg.data().size(), pixFormat);
+    const char *buffer = (const char *)_msg.data().c_str();
+    uint buffer_size = _msg.data().size();
+    mFrameBuffer = std::vector<uint8_t>(buffer, buffer + buffer_size);
+
+#if 0
+    std::ofstream fout("imgframe.rgb", std::ios::binary);
+    fout.write(reinterpret_cast<char*>(&mFrameBuffer[0]), mFrameBuffer.size() * sizeof(mFrameBuffer[0]));
+    fout.close();
+    std::cout<<"\nsaved";
+#endif
+
+    return success;
+}

--- a/src/CameraDeviceGazebo.cpp
+++ b/src/CameraDeviceGazebo.cpp
@@ -60,6 +60,11 @@ int CameraDeviceGazebo::getInfo(struct CameraInfo &camInfo)
     return 0;
 }
 
+bool CameraDeviceGazebo::isGstV4l2Src()
+{
+    return false;
+}
+
 int CameraDeviceGazebo::init(CameraParameters &camParam)
 {
     return 0;

--- a/src/CameraDeviceGazebo.cpp
+++ b/src/CameraDeviceGazebo.cpp
@@ -120,6 +120,17 @@ int CameraDeviceGazebo::getPixelFormat(uint32_t &format)
     return 0;
 }
 
+int CameraDeviceGazebo::setMode(uint32_t mode)
+{
+    mMode = mode;
+    return 0;
+}
+
+int CameraDeviceGazebo::getMode()
+{
+    return mMode;
+}
+
 void CameraDeviceGazebo::cbOnImages(ConstImagesStampedPtr &_msg)
 {
     std::lock_guard<std::mutex> locker(mLock);

--- a/src/CameraDeviceGazebo.h
+++ b/src/CameraDeviceGazebo.h
@@ -34,18 +34,16 @@ public:
     int start();
     int stop();
     std::vector<uint8_t> read();
-    std::string getDevice();
-    int getWidth();
-    int getHeight();
-    int getPixelFormat();
+    int getSize(uint32_t &width, uint32_t &height);
+    int getPixelFormat(uint32_t &format);
 
 private:
     void cbOnImages(ConstImagesStampedPtr &_msg);
     int getImage(const gazebo::msgs::Image &_msg);
     std::string mDeviceId;
-    int mWidth;
-    int mHeight;
-    int mPixelFormat;
+    uint32_t mWidth;
+    uint32_t mHeight;
+    uint32_t mPixelFormat;
     std::string mTopicName;
     gazebo::transport::NodePtr mNode;
     gazebo::transport::SubscriberPtr mSub;

--- a/src/CameraDeviceGazebo.h
+++ b/src/CameraDeviceGazebo.h
@@ -37,11 +37,14 @@ public:
     std::vector<uint8_t> read();
     int getSize(uint32_t &width, uint32_t &height);
     int getPixelFormat(uint32_t &format);
+    int setMode(uint32_t mode);
+    int getMode();
 
 private:
     void cbOnImages(ConstImagesStampedPtr &_msg);
     int getImage(const gazebo::msgs::Image &_msg);
     std::string mDeviceId;
+    int mMode;
     uint32_t mWidth;
     uint32_t mHeight;
     uint32_t mPixelFormat;

--- a/src/CameraDeviceGazebo.h
+++ b/src/CameraDeviceGazebo.h
@@ -29,6 +29,7 @@ public:
     ~CameraDeviceGazebo();
     std::string getDeviceId();
     int getInfo(struct CameraInfo &camInfo);
+    bool isGstV4l2Src();
     int init(CameraParameters &camParam);
     int uninit();
     int start();

--- a/src/CameraDeviceGazebo.h
+++ b/src/CameraDeviceGazebo.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Camera Streaming Daemon
+ *
+ * Copyright (C) 2017  Intel Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <gazebo/msgs/msgs.hh>
+#include <gazebo/transport/transport.hh>
+#include <string>
+
+#include "CameraDevice.h"
+#include "CameraParameters.h"
+
+class CameraDeviceGazebo final : public CameraDevice {
+public:
+    CameraDeviceGazebo(std::string device);
+    ~CameraDeviceGazebo();
+    std::string getDeviceId();
+    int getInfo(struct CameraInfo &camInfo);
+    int init(CameraParameters &camParam);
+    int uninit();
+    int start();
+    int stop();
+    std::vector<uint8_t> read();
+    std::string getDevice();
+    int getWidth();
+    int getHeight();
+    int getPixelFormat();
+
+private:
+    void cbOnImages(ConstImagesStampedPtr &_msg);
+    int getImage(const gazebo::msgs::Image &_msg);
+    std::string mDeviceId;
+    int mWidth;
+    int mHeight;
+    int mPixelFormat;
+    std::string mTopicName;
+    gazebo::transport::NodePtr mNode;
+    gazebo::transport::SubscriberPtr mSub;
+    std::mutex mLock;
+    std::vector<uint8_t> mFrameBuffer = {};
+};

--- a/src/CameraDeviceV4l2.cpp
+++ b/src/CameraDeviceV4l2.cpp
@@ -104,6 +104,11 @@ int CameraDeviceV4l2::getInfo(struct CameraInfo &camInfo)
     return 0;
 }
 
+bool CameraDeviceV4l2::isGstV4l2Src()
+{
+    return true;
+}
+
 int CameraDeviceV4l2::setSize(uint32_t width, uint32_t height)
 {
     return 0;

--- a/src/CameraDeviceV4l2.h
+++ b/src/CameraDeviceV4l2.h
@@ -30,8 +30,9 @@ public:
     int start();
     int stop();
     std::vector<uint8_t> read();
-    int getInfo(struct CameraInfo &camInfo);
     std::string getDeviceId();
+    int getInfo(struct CameraInfo &camInfo);
+    bool isGstV4l2Src();
     int setSize(uint32_t width, uint32_t height);
     int setPixelFormat(uint32_t format);
     int setMode(uint32_t mode);

--- a/src/CameraParameters.h
+++ b/src/CameraParameters.h
@@ -200,8 +200,9 @@ public:
     static const int ID_PIXEL_FORMAT_YUV420SP = 1;
     static const int ID_PIXEL_FORMAT_YUV422I = 2;
     static const int ID_PIXEL_FORMAT_YUV420P = 3;
-    static const int ID_PIXEL_FORMAT_RGB565 = 4;
-    static const int ID_PIXEL_FORMAT_RGBA8888 = 5;
+    static const int ID_PIXEL_FORMAT_RGB565 = 4; // RGBP
+    static const int ID_PIXEL_FORMAT_RGB24 = 5;  // RGB3
+    static const int ID_PIXEL_FORMAT_RGB32 = 6;  // RGB4
 
     // TODO :: Make exhaustive list of parameters and its possible values
 private:

--- a/src/CameraServer.cpp
+++ b/src/CameraServer.cpp
@@ -72,18 +72,21 @@ int CameraServer::detectCamera(ConfFile &conf)
 {
     int count = 0;
 
+#ifdef ENABLE_GAZEBO
     // Check for SITL gazebo first, if not found search for other devices
     // It is possible to have gazebo camera with real camera but not enabling
     // this for now
     count += detect_devices_gazebo(conf, cameraList);
     if (count > 0)
         return count;
+#endif
 
     count += detect_devices_v4l2(conf, cameraList);
 
     return count;
 }
 
+#ifdef ENABLE_GAZEBO
 int CameraServer::detect_devices_gazebo(ConfFile &conf, std::vector<CameraComponent *> &camList)
 {
     char *uri_addr = 0;
@@ -104,6 +107,7 @@ int CameraServer::detect_devices_gazebo(ConfFile &conf, std::vector<CameraCompon
 
     return 1;
 }
+#endif
 
 int CameraServer::detect_devices_v4l2(ConfFile &conf, std::vector<CameraComponent *> &camList)
 {

--- a/src/CameraServer.h
+++ b/src/CameraServer.h
@@ -38,7 +38,9 @@ public:
 
 private:
     std::string getImgCapLocation(ConfFile &conf);
+    std::string getGazeboCamTopic(ConfFile &conf);
     int detectCamera(ConfFile &conf);
+    int detect_devices_gazebo(ConfFile &conf, std::vector<CameraComponent *> &camList);
     int detect_devices_v4l2(ConfFile &conf, std::vector<CameraComponent *> &cameraList);
     MavlinkServer mavlink_server;
     RTSPServer rtsp_server;

--- a/src/CameraServer.h
+++ b/src/CameraServer.h
@@ -40,7 +40,9 @@ private:
     std::string getImgCapLocation(ConfFile &conf);
     std::string getGazeboCamTopic(ConfFile &conf);
     int detectCamera(ConfFile &conf);
+#ifdef ENABLE_GAZEBO
     int detect_devices_gazebo(ConfFile &conf, std::vector<CameraComponent *> &camList);
+#endif
     int detect_devices_v4l2(ConfFile &conf, std::vector<CameraComponent *> &cameraList);
     MavlinkServer mavlink_server;
     RTSPServer rtsp_server;

--- a/src/ImageCaptureGst.cpp
+++ b/src/ImageCaptureGst.cpp
@@ -70,12 +70,11 @@ int ImageCaptureGst::start(int interval, int count, std::function<void(int resul
 
 int ImageCaptureGst::stop()
 {
-    if (mState == STATE_IDLE)
-        return 0;
-
     setState(STATE_IDLE);
 
-    // TODO::thread_join if mThread legal
+    if (mThread.joinable())
+        mThread.join();
+
     return 0;
 }
 

--- a/src/ImageCaptureGst.cpp
+++ b/src/ImageCaptureGst.cpp
@@ -147,9 +147,13 @@ void ImageCaptureGst::captureThread(int num, int interval)
 
 int ImageCaptureGst::click(int seq_num)
 {
-    int ret = 0;
     log_debug("%s", __func__);
-    ret = createV4l2Pipeline(seq_num);
+
+    int ret = 0;
+    if (mCamDev->isGstV4l2Src())
+        ret = createV4l2Pipeline(seq_num);
+    else
+        ret = createAppsrcPipeline(seq_num);
     return ret;
 }
 
@@ -166,16 +170,27 @@ std::string ImageCaptureGst::getGstImgEncName(int format)
     }
 }
 
+std::string ImageCaptureGst::getGstPixFormat(int pixFormat)
+{
+    switch (pixFormat) {
+    case CameraParameters::ID_PIXEL_FORMAT_RGB24:
+        return "RGB";
+        break;
+    default:
+        return {};
+    }
+}
+
 std::string ImageCaptureGst::getImgExt(int format)
 {
     switch (format) {
     case CameraParameters::ID_IMAGE_FORMAT_JPEG:
         return "jpg";
-        break;
-    case CameraParameters::ID_IMAGE_FORMAT_RAW:
     case CameraParameters::ID_IMAGE_FORMAT_PNG:
+        return "png";
+    case CameraParameters::ID_IMAGE_FORMAT_RAW:
     default:
-        return {};
+        return "raw";
     }
 }
 
@@ -203,6 +218,8 @@ std::string ImageCaptureGst::getGstPipelineNameV4l2(int seq_num)
 
 int ImageCaptureGst::createV4l2Pipeline(int seq_num)
 {
+    log_info("%s", __func__);
+
     int ret = 0;
     GError *error = nullptr;
     GstElement *pipeline;
@@ -258,5 +275,116 @@ int ImageCaptureGst::createV4l2Pipeline(int seq_num)
     gst_object_unref(bus);
 
     log_debug("Image Captured Successfully");
+    return ret;
+}
+
+static void cbNeedData(GstElement *appsrc, guint unused_size, ImageCaptureGst *obj)
+{
+    log_debug("%s", __func__);
+
+    GstFlowReturn ret;
+    std::vector<uint8_t> frame = obj->mCamDev->read();
+    uint8_t *data = &frame[0];
+    gsize size = frame.size(); // width*height*3/2/1.5
+    gsize offset = 0;
+    gsize maxsize = size;
+    GstBuffer *buffer
+        = gst_buffer_new_wrapped_full((GstMemoryFlags)0, data, maxsize, offset, size, NULL, NULL);
+    assert(buffer);
+
+    g_signal_emit_by_name(appsrc, "push-buffer", buffer, &ret);
+    gst_buffer_unref(buffer);
+    if (ret != GST_FLOW_OK) {
+        /* some error */
+        log_error("Error in sending data to gst pipeline");
+    }
+    g_signal_emit_by_name(appsrc, "end-of-stream", &ret);
+    // gst_app_src_end_of_stream (appsrc);
+}
+
+int ImageCaptureGst::createAppsrcPipeline(int seq_num)
+{
+    log_info("%s", __func__);
+
+    int ret = 0;
+    GstElement *pipeline, *appsrc, *enc, *imagesink;
+    GstMessage *msg;
+
+    std::string encname = getGstImgEncName(mImgFormat);
+    if (encname.empty())
+        return {};
+
+    std::string fmt = getGstPixFormat(mPixelFormat);
+    if (fmt.empty())
+        return {};
+
+    std::string ext = getImgExt(mImgFormat);
+    if (ext.empty())
+        return {};
+
+    /* setup pipeline */
+    pipeline = gst_pipeline_new("pipeline");
+    appsrc = gst_element_factory_make("appsrc", "source");
+    enc = gst_element_factory_make(encname.c_str(), "enc");
+    imagesink = gst_element_factory_make("filesink", "imagesink");
+    std::string filepath = mImgPath + "img_" + std::to_string(seq_num) + "." + ext;
+    g_object_set(G_OBJECT(imagesink), "location", filepath.c_str(), NULL);
+
+    log_info("Pipeline Format:RGB, width:%d, Height:%d", mWidth, mHeight);
+    log_info("Pipeline File:%s", filepath.c_str());
+
+    /* setup */
+    g_object_set(G_OBJECT(appsrc), "caps",
+                 gst_caps_new_simple("video/x-raw", "format", G_TYPE_STRING, fmt.c_str(), "width",
+                                     G_TYPE_INT, mWidth, "height", G_TYPE_INT, mHeight, "framerate",
+                                     GST_TYPE_FRACTION, 0, 1, NULL),
+                 NULL);
+    gst_bin_add_many(GST_BIN(pipeline), appsrc, enc, imagesink, NULL);
+    gst_element_link_many(appsrc, enc, imagesink, NULL);
+
+    /* setup appsrc */
+    g_object_set(G_OBJECT(appsrc), "stream-type", 0, // GST_APP_STREAM_TYPE_STREAM
+                 "format", GST_FORMAT_TIME, "is-live", TRUE, NULL);
+    g_signal_connect(appsrc, "need-data", G_CALLBACK(cbNeedData), this);
+
+    /* play */
+    gst_element_set_state(pipeline, GST_STATE_PLAYING);
+
+    /* add watch for messages */
+    GstBus *bus = gst_pipeline_get_bus(GST_PIPELINE(pipeline));
+    // gst_bus_add_watch (bus, (GstBusFunc) bus_message, NULL);
+    msg = gst_bus_poll(bus, (GstMessageType)(GST_MESSAGE_EOS | GST_MESSAGE_ERROR), -1);
+    switch (GST_MESSAGE_TYPE(msg)) {
+    case GST_MESSAGE_EOS: {
+        log_error("EOS\n");
+        ret = 0;
+        break;
+    }
+    case GST_MESSAGE_ERROR: {
+        GError *err = NULL; /* error to show to users                 */
+        gchar *dbg = NULL;  /* additional debug string for developers */
+
+        gst_message_parse_error(msg, &err, &dbg);
+        if (err) {
+            log_error("ERROR: %s\n", err->message);
+            g_error_free(err);
+        }
+        if (dbg) {
+            log_error("[Debug details: %s]\n", dbg);
+            g_free(dbg);
+        }
+        ret = 1;
+        break;
+    }
+    default:
+        log_error("Unexpected message of type %d", GST_MESSAGE_TYPE(msg));
+        ret = 1;
+        break;
+    }
+
+    /* clean up */
+    gst_element_set_state(pipeline, GST_STATE_NULL);
+    gst_object_unref(GST_OBJECT(pipeline));
+
     return ret;
 }

--- a/src/ImageCaptureGst.cpp
+++ b/src/ImageCaptureGst.cpp
@@ -32,10 +32,13 @@ ImageCaptureGst::ImageCaptureGst(std::shared_ptr<CameraDevice> camDev)
     , mWidth(640)
     , mHeight(480)
     , mImgFormat(CameraParameters::ID_IMAGE_FORMAT_JPEG)
-    , mPixelFormat(-1)
+    , mPixelFormat(0)
     , mImgPath("/tmp/")
     , mResultCB(nullptr)
 {
+    mCamDev->getSize(mWidth, mHeight);
+
+    mCamDev->getPixelFormat(mPixelFormat);
 }
 
 ImageCaptureGst::~ImageCaptureGst()

--- a/src/ImageCaptureGst.h
+++ b/src/ImageCaptureGst.h
@@ -30,6 +30,7 @@ public:
     int setResolution(int imgWidth, int imgHeight);
     int setFormat(int imgFormat);
     int setLocation(const std::string imgPath);
+    std::shared_ptr<CameraDevice> mCamDev;
 
 private:
     int setState(int state);
@@ -39,13 +40,12 @@ private:
     std::string getGstImgEncName(int format);
     std::string getImgExt(int format);
     std::string getGstPipelineNameV4l2(int seq_num);
-    std::shared_ptr<CameraDevice> mCamDev;
     std::string mDevice;
     std::atomic<int> mState;
-    int mWidth;
-    int mHeight;
-    int mImgFormat;
-    int mPixelFormat;
+    uint32_t mWidth;
+    uint32_t mHeight;
+    uint32_t mImgFormat;
+    uint32_t mPixelFormat;
     std::string mImgPath;
     std::function<void(int result, int seq_num)> mResultCB;
     std::thread mThread;

--- a/src/ImageCaptureGst.h
+++ b/src/ImageCaptureGst.h
@@ -38,8 +38,10 @@ private:
     void captureThread(int num, int interval);
     int createV4l2Pipeline(int seq_num);
     std::string getGstImgEncName(int format);
+    std::string getGstPixFormat(int pixFormat);
     std::string getImgExt(int format);
     std::string getGstPipelineNameV4l2(int seq_num);
+    int createAppsrcPipeline(int seq_num);
     std::string mDevice;
     std::atomic<int> mState;
     uint32_t mWidth;

--- a/src/socket.cpp
+++ b/src/socket.cpp
@@ -138,6 +138,13 @@ int UDPSocket::open(bool broadcast)
         return -1;
     }
 
+#ifdef ENABLE_GAZEBO
+    // bind socket to port
+    if (bind("0.0.0.0", 34550) == -1) {
+        log_error("bind");
+    }
+#endif
+
     if (broadcast) {
         if (setsockopt(_fd, SOL_SOCKET, SO_BROADCAST, &broadcast_val, sizeof(broadcast_val))) {
             log_error("Error enabling broadcast in socket (%m)");


### PR DESCRIPTION
Gazebo Camera Plugin is added as a CameraDevice that will listen to the
subscribed topic and handle the image frames coming from gazebo.